### PR TITLE
Basic CanPvP Logic

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10063,6 +10063,10 @@ bool Client::CanPvP(Client *c) {
 	if (c->GetGM())
 		return false;
 
+	// guildies cant PK each other??
+	if (GuildID() == c->GuildID())
+		return false;
+
 	// pvp always allowed outside of cities (can attacker trainers/pnp trolls)
 	if (!zone->IsCity(/*zone->GetZoneID()*/))
 		return true;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10074,7 +10074,7 @@ bool Client::CanPvP(Client *c) {
 
 	// check player level range
 	int rule_level_diff = RuleI(World, PVPLevelDifference);
-	if (abs(c->GetLevel() - GetLevel()) > rule_level_diff)
+	if (abs((std::int16_t)c->GetLevel() - (std::int16_t)GetLevel()) > rule_level_diff)
 		return false;
 		
 	return true;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10074,7 +10074,7 @@ bool Client::CanPvP(Client *c) {
 
 	// check player level range
 	int rule_level_diff = RuleI(World, PVPLevelDifference);
-	if (abs((std::int16_t)c->GetLevel() - (std::int16_t)GetLevel()) > rule_level_diff)
+	if (abs((int16)c->GetLevel() - (int16)GetLevel()) > rule_level_diff)
 		return false;
 		
 	return true;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10067,6 +10067,9 @@ bool Client::CanPvP(Client *c) {
 	if (GuildID() == c->GuildID())
 		return false;
 
+	if (GetGroup()->GetID() == c->GetGroup()->GetID())
+		return false;
+
 	// pvp always allowed outside of cities (can attacker trainers/pnp trolls)
 	if (!zone->IsCity(/*zone->GetZoneID()*/))
 		return true;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10058,52 +10058,23 @@ bool Client::CanPvP(Client *c) {
 	//Dueling overrides normal PvP logic
 	if (IsDueling() && c->IsDueling() && GetDuelTarget() == c->GetID() && c->GetDuelTarget() == GetID())
 		return true;
-	
-	// if both are in a pvp area, or discord, return true
-	//if (GetPVP() && c->GetPVP()) --commented out 2/28/21 to troubleshoot an issue... Darksinga
-	//	return true;
 
-	//If PVPLevelDifference is enabled, only allow PVP if players are of proper range
-	int rule_level_diff = 0;
-	if (RuleI(World, PVPSettings) == 4)
-		rule_level_diff = 4; //Sullon Zek rules can attack anyone of opposing deity.
-	if (RuleI(World, PVPLevelDifference) > 0)
-		rule_level_diff = RuleI(World, PVPLevelDifference);
-
-	if (rule_level_diff > 0) {
-		int level_diff = 0;
-		if (c->GetLevel() > GetLevel())
-			level_diff = c->GetLevel() - GetLevel();
-		else 
-			level_diff = GetLevel() - c->GetLevel();
-		if (GetZoneID() == 71 || GetZoneID() == 72 || GetZoneID() == 76 || GetZoneID() == 77 || GetZoneID() == 39 || GetZoneID() == 89 || GetZoneID() == 108 || GetZoneID() == 124 || GetZoneID() == 128 && GetZoneID() == 26) {
-
-		}
-		else {
-			if (level_diff > rule_level_diff && !GetGM())
-				return false;
-		}
-	}
-
-	//players need to be proper level for pvp
-	int rule_min_level = 0;
-	if (RuleI(World, PVPSettings) == 4)
-		rule_min_level = 1;
-	if (RuleI(World, PVPMinLevel) > 0)
-		rule_min_level = RuleI(World, PVPMinLevel);
-
-	if (rule_min_level > 0 && (GetLevel() < rule_min_level || c->GetLevel() < rule_min_level))
+	// protect GMs by default, (this one sided logic should allow GM to smack people tho)
+	if (c->GetGM())
 		return false;
 
-	//is deity pvp rule enabled? If so, if we're same alignment, don't allow pvp
-	if ((RuleI(World, PVPSettings) == 4 || RuleB(World, PVPUseDeityBasedPVP)) && GetAlignment() == c->GetAlignment() && !GetZoneID() == 26 && !GetZoneID() == 77)
-		return false;
-	
-	//VZTZ Zek PVP Setting
-	if ((RuleI(World, PVPSettings) == 2 || RuleB(World, PVPUseTeamsBySizeBasedPVP)) && GetPVPRaceTeamBySize() == c->GetPVPRaceTeamBySize())
+	// pvp always allowed outside of cities (can attacker trainers/pnp trolls)
+	if (zone->IsCity(/*zone->GetZoneID()*/))
+		return true;
+
+	// players need to be min level for pvp
+	int rule_min_level = RuleI(World, PVPMinLevel);
+	if (GetLevel() < rule_min_level || c->GetLevel() < rule_min_level)
 		return false;
 
-	if (GetAlignment() == c->GetAlignment() && !GetGM())
+	// check player level range
+	int rule_level_diff = RuleI(World, PVPLevelDifference);
+	if (abs(c->GetLevel() - GetLevel()) > rule_level_diff)
 		return false;
 		
 	return true;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10064,7 +10064,7 @@ bool Client::CanPvP(Client *c) {
 		return false;
 
 	// pvp always allowed outside of cities (can attacker trainers/pnp trolls)
-	if (zone->IsCity(/*zone->GetZoneID()*/))
+	if (!zone->IsCity(/*zone->GetZoneID()*/))
 		return true;
 
 	// players need to be min level for pvp


### PR DESCRIPTION
Logic flow top to bottom:

1. Duelers can FIGHT
2. GMs cant be attacked
3. Guildies can't attack each other
4. Groupies can't attack each other 
5. If zone is not a city, FIGHT
6. If one of the players is not min pvp level (and in city cuz of above), cant attack
7. If the players are not in range of each other (and in city cuz of above), cant attack
8. FIGHT

In current state of `Mob::IsBeneficialAllowed`, inverse operations allow buffs/heals, might need to be changed because it's not a 1:1.

Any other situations to add to this PR?