### PR TITLE
Allow beneficials

### DIFF
--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -689,7 +689,7 @@ bool Mob::IsBeneficialAllowed(Mob *target)
 				c1 = mob1->CastToClient();
 				c2 = mob2->CastToClient();
 
-				return !c1->CanPvP(c2);
+				return true; //!c1->CanPvP(c2);
 			}
 			else if(_NPC(mob2))				// client to npc
 			{


### PR DESCRIPTION
As mentioned in #1 the old `CanPvP()` function was more oriented toward teams.

This makes it so anyone can cast a beneficial spell on anyone. I can't think of scenarios we wouldn't want that? (oor healer stuff kinda negligible when most zones are FFA)