### PR TITLE
PVPPointsRework

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1632,11 +1632,11 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::Skill
 
 	if (!ClientFinishedLoading())
 		damage = -5;
-	
+
 	if (other != nullptr && iBuffTic && is_client_moving && !IsRooted() && !IsFeared() && !IsRunning() && !IsBardSong(spell_id)) { //If the target is moving dots only do partial damage
 		damage = (damage * .66);
 	}
-	
+
 
 	//do a majority of the work...
 	CommonDamage(other, damage, spell_id, attack_skill, avoidable, buffslot, iBuffTic, special);
@@ -1745,7 +1745,7 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 			killerMob->TrySpellOnKill(killed_level, spell);
 		}
 
-		if (killerMob->IsClient() && (IsDueling() || killerMob->CastToClient()->IsDueling())) 
+		if (killerMob->IsClient() && (IsDueling() || killerMob->CastToClient()->IsDueling()))
 		{
 			SetDueling(false);
 			SetDuelTarget(0);
@@ -1775,7 +1775,7 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 			std::vector<EQ::Any> args;
 			args.push_back(victim);
 
-			int pvp_points = 0; 
+			int pvp_points = 0;
 
 			// naez: 0 points for farming your own
 			if (killerMob->CastToClient()->GetIP() != victim->CastToClient()->GetIP()) {
@@ -1788,29 +1788,32 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 			  	if (group != 0)
 			  	{
 					uint8 gcount = group->GroupCount();
+					//Brynja: this is the old Live system
+					// if (gcount > 4) {
+					// 	pvp_points = pvp_points * 1.1;
+					// }
+					// if (gcount == 5) {
+					// 	pvp_points = pvp_points * 1.15;
+					// }
+					// if (gcount == 6) {
+					// 	pvp_points = pvp_points * 1.2;
+					// }
 
-					if (gcount > 4) {
-						pvp_points = pvp_points * 1.1;
-					}
-					if (gcount == 5) {	
-						pvp_points = pvp_points * 1.15;
-					}
-					if (gcount == 6) {	
-						pvp_points = pvp_points * 1.2;
-					}
+					//Brynja: pvp points are divided evenly among group members, rounded down
+					pvp_points = pvp_points - floor(pvp_points / gcount);
 
 					for (int i = 0; i<6; i++)
 					{
 						if (group->members[i] != nullptr)
 						{
-							database.RegisterPVPKill(group->members[i]->CastToClient(), victim, pvp_points); 
+							database.RegisterPVPKill(group->members[i]->CastToClient(), victim, pvp_points);
 
 							group->members[i]->CastToClient()->HandlePVPKill(pvp_points);
 						}
 					}
 			  	}
 			} else {
-				database.RegisterPVPKill(killerMob->CastToClient(), victim, pvp_points); 
+				database.RegisterPVPKill(killerMob->CastToClient(), victim, pvp_points);
 
 				killerMob->CastToClient()->HandlePVPKill(pvp_points);
 			}
@@ -1867,23 +1870,23 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 		{
 			LogCombat("killer mob is client [{}]", killerMob->GetName());
 			int pvpleveldifference = 0;
-			//if (RuleI(World, PVPSettings) == 4) 
-				//pvpleveldifference = 5; //Sullon Zek 
+			//if (RuleI(World, PVPSettings) == 4)
+				//pvpleveldifference = 5; //Sullon Zek
 			if (RuleI(World, PVPLoseExperienceLevelDifference) > 0)
 				pvpleveldifference = RuleI(World, PVPLoseExperienceLevelDifference);
 
 			if (pvpleveldifference > 0) {
-				
+
  				int level_difference = 0;
- 				if (GetLevel() > killerMob->GetLevel()) 
+ 				if (GetLevel() > killerMob->GetLevel())
 					level_difference = GetLevel() - killerMob->GetLevel();
- 				else 
+ 				else
 					level_difference = killerMob->GetLevel() - GetLevel();
  				LogCombat("pvpleveldifference is [{}] and level_difference is [{}]", pvpleveldifference, level_difference);
- 				if (level_difference > pvpleveldifference) 
+ 				if (level_difference > pvpleveldifference)
 					exploss = 0;
  			}
- 			else 
+ 			else
  			{
  				exploss = 0;
  			}
@@ -1903,7 +1906,7 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 			if (buffs[buffIt].spellid == spell)
 			{
 				strcpy(caster_name, buffs[buffIt].caster_name);
-				if (buffs[buffIt].client) 
+				if (buffs[buffIt].client)
 				{
 					exploss = 0;	// no exp loss for pvp dot
 					break;
@@ -2065,7 +2068,7 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 		std::string event_desc = StringFormat("Died in zoneid:%i instid:%i by '%s', spellid:%i, damage:%i", this->GetZoneID(), this->GetInstanceID(), killer_name, spell, damage);
 		QServ->PlayerLogEvent(Player_Log_Deaths, this->CharacterID(), event_desc);
 	}
-	
+
 	if (killerMob && strlen(caster_name) > 0 && strcmp(killerMob->GetName(), caster_name) == -1)
 	{
 		snprintf(buffer, 63, "%d %d %d %d %s", 0, damage, spell, static_cast<int>(attack_skill), caster_name);
@@ -3609,9 +3612,9 @@ bool Mob::CheckDoubleAttack()
 	int per_inc = aabonuses.DoubleAttackChance + spellbonuses.DoubleAttackChance + itembonuses.DoubleAttackChance;
 	if (per_inc)
 		chance += chance * per_inc / 100;
-	
+
 	// Voidd: TODO - Make rule for when mobs get double attack?
-	
+
 	//mobs don't double attack until 17
 	if (IsNPC() && GetLevel() < 17) {
 		chance = 0;
@@ -5244,8 +5247,8 @@ bool Mob::TryRootFadeByDamage(int buffslot, Mob* attacker) {
 		int BreakChance = RuleI(Spells, RootBreakFromSpells);
 		if (attacker && attacker->IsClient() && IsClient()) {
 			if (RuleI(World, PVPSettings) > 0) BreakChance = 75; //All PVP servers is default 75% chance for root to break
-				
-			
+
+
 			if (RuleI(Spells, PVPRootBreakFromSpells) > 0) BreakChance = RuleI(Spells, PVPRootBreakFromSpells);
 		}
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -269,8 +269,8 @@ Client::Client(EQStreamInterface* ieqs)
 	if (RuleI(World, PVPSettings) > 0) SendPVPStats();
 
 	if (WorldPVPMinLevel() > 0 && level >= WorldPVPMinLevel() && m_pp.pvp == 0) SetPVP(true, false);
-	
-	
+
+
 	dynamiczone_removal_timer.Disable();
 
 	//for good measure:
@@ -4296,7 +4296,7 @@ void Client::LevelFirst(uint32 p_race, uint32 p_class, uint16 level) {
 							"leveled_date = UNIX_TIMESTAMP(), account_status = %i",
 							GetName(), p_race, p_class, level, Admin());
 		auto results = database.QueryDatabase(query);
-		
+
 		//parse->EventPlayer(EVENT_SERVERFIRST_LEVEL, this, "", 0);
 	}
 }
@@ -10054,14 +10054,14 @@ void Client::Fling(float value, float target_x, float target_y, float target_z, 
 
 //CanPvP returns true if provided player can attack this player
 bool Client::CanPvP(Client *c) {
-	
+
 	// No Target
-	if (c == nullptr) 
+	if (c == nullptr)
 	{
 		LogDebug("Client::CanPvP other was null");
 		return false;
 	}
-	
+
 	// protect GMs by default, (this one sided logic should allow GM to smack people tho)
 	if (c->GetGM())
 	{
@@ -10075,7 +10075,7 @@ bool Client::CanPvP(Client *c) {
 		LogDebug("Client::CanPvP everyone was dueling, FIGHT");
 		return true;
 	}
-	
+
 	// Is PVP Disabled, otherwise continue with pvp checks
 	if(RuleI(World, PVPSettings) == 0)
 		return false;
@@ -10090,39 +10090,39 @@ bool Client::CanPvP(Client *c) {
 	{
 		LogDebug("Client::CanPvP World:WorldPVPMinLevel Passed, Level [{}], Target Level [{}], Min Level Rule [{}]", GetLevel(), c->GetLevel(), WorldPVPMinLevel());
 	}
-	
+
 	// Is VZ/TZ Ruleset turned on and is target on opposing team
 	if(!WorldPVPUseTeamsBySizeBasedPVP(c))
 		return false;
-	
+
 	// Is Guild based ruleset turned on and is target on opposing guild
 	if(!WorldPVPUseGuildBasedPVP(c))
 		return false;
-	
+
 	// Is SZ Ruleset turned on and is target on opposing deity (Good vs Evil)
 	if(!WorldPVPUseDeityBasedPVP(c))
 		return false;
 
 	if(!PVPLevelDifference(c))
 		return false;
-	
+
 	return true;
 }
 
 bool Client::PVPLevelDifference(Client *c)
 {
 	int rule_level_diff = RuleI(World, PVPLevelDifference);
-	
+
 	// If rule is set to anything other than 0 its custom
 	if(rule_level_diff == 0) {
-		if(RuleI(World, PVPSettings) == 1) 
+		if(RuleI(World, PVPSettings) == 1)
 		{
 			rule_level_diff = 4;
 		}
 		// Vallon/Tallon Zek
 		else if(RuleI(World, PVPSettings) == 2)
 		{
-			rule_level_diff = 8; 
+			rule_level_diff = 8;
 		}
 		// Sullon Zek
 		else if(RuleI(World, PVPSettings) == 4)
@@ -10131,7 +10131,7 @@ bool Client::PVPLevelDifference(Client *c)
 			return true;
 		}
 	}
-	
+
 	LogDebug("Client::CanPvP World:PVPLevelDifference Rule Level Diff: [{}], Level: [{}], Other Level: [{}]", rule_level_diff, GetLevel(), c->GetLevel());
 
 	// Compare Levels
@@ -10140,55 +10140,55 @@ bool Client::PVPLevelDifference(Client *c)
 		LogDebug("Client::CanPvP World:PVPLevelDifference Failed, Failed Difference [{}]", abs(GetLevel() - c->GetLevel()));
 		return false;
 	}
-	
+
 	LogDebug("Client::CanPvP World:PVPLevelDifference Passed");
 	return true;
 }
 
 bool Client::WorldPVPUseGuildBasedPVP(Client *c)
 {
-	
+
 	if(RuleI(World, PVPSettings) != 3)
 		return true;
-	
+
 	if((GuildID() == c->GuildID()) && (IsInAGuild() && c->IsInAGuild()))
 	{
 		LogDebug("Client::CanPvP World:WorldPVPUseGuildBasedPVP Failed, Client [{}], Other [{}], IsInAGuild [{}], IsInAGuild Other [{}]", GuildID(), c->GuildID(), IsInAGuild(), c->IsInAGuild());
 		return false;
 	}
-	
+
 	LogDebug("Client::CanPvP World:WorldPVPUseGuildBasedPVP Passed, Client [{}], Other [{}]", GuildID(), c->GuildID());
 	return true;
 }
 
 bool Client::WorldPVPUseTeamsBySizeBasedPVP(Client *c)
 {
-	
+
 	if(RuleI(World, PVPSettings) != 2)
 		return true;
-	
+
 	if(GetPVPRaceTeamBySize() == c->GetPVPRaceTeamBySize())
 	{
 		LogDebug("Client::CanPvP World:WorldPVPUseTeamsBySizeBasedPVP Failed, Client [{}], Other [{}]", GetPVPRaceTeamBySize(), c->GetPVPRaceTeamBySize());
 		return false;
 	}
-	
+
 	LogDebug("Client::CanPvP World:WorldPVPUseTeamsBySizeBasedPVP Passed, Client [{}], Other [{}]", GetPVPRaceTeamBySize(), c->GetPVPRaceTeamBySize());
 	return true;
 }
 
 bool Client::WorldPVPUseDeityBasedPVP(Client *c)
 {
-	
+
 	if(RuleI(World, PVPSettings) != 4)
 		return true;
-	
+
 	if(GetAlignment() == c->GetAlignment())
 	{
 		LogDebug("Client::CanPvP World:WorldPVPUseDeityBasedPVP Failed, Client [{}], Other [{}]", GetAlignment(), c->GetAlignment());
 		return false;
 	}
-	
+
 	LogDebug("Client::CanPvP World:WorldPVPUseDeityBasedPVP Passed, Client [{}], Other [{}]", GetAlignment(), c->GetAlignment());
 	return true;
 }
@@ -10196,7 +10196,7 @@ bool Client::WorldPVPUseDeityBasedPVP(Client *c)
 int Client::WorldPVPMinLevel()
 {
 	int rule_min_level = RuleI(World, PVPMinLevel);
-	
+
 	// If rule is set to anything other than 0 its custom
 	if(rule_min_level == 0)
 	{
@@ -10205,15 +10205,15 @@ int Client::WorldPVPMinLevel()
 			case 1: // Rallos Zek
 				rule_min_level = 6;
 			break;
-			
+
 			case 2: // Vallon/Tallon Zek (Size)
 				rule_min_level = 6;
 			break;
-			
+
 			case 3: // Vallon/Tallon Zek (Guild)
 				rule_min_level = 6;
 			break;
-			
+
 			case 4: // Sullon Zek
 				rule_min_level = 6;
 			break;
@@ -10224,14 +10224,14 @@ int Client::WorldPVPMinLevel()
 
 //GetAlignment returns 0 = neutral, 1 = good, 2 = evil, used for pvp sullon zek rules
 int Client::GetAlignment() {
-	if (GetDeity() == EQ::deity::DeityErollisiMarr || 
+	if (GetDeity() == EQ::deity::DeityErollisiMarr ||
 		GetDeity() == EQ::deity::DeityMithanielMarr ||
-		GetDeity() == EQ::deity::DeityRodcetNife || 
-		GetDeity() == EQ::deity::DeityQuellious || 
+		GetDeity() == EQ::deity::DeityRodcetNife ||
+		GetDeity() == EQ::deity::DeityQuellious ||
 		GetDeity() == EQ::deity::DeityTunare) return 1; //good
 	if (GetDeity() == EQ::deity::DeityBertoxxulous ||
 		GetDeity() == EQ::deity::DeityCazicThule ||
-		GetDeity() == EQ::deity::DeityInnoruuk || 
+		GetDeity() == EQ::deity::DeityInnoruuk ||
 		GetDeity() == EQ::deity::DeityRallosZek) return 2; //evil
 	return 0; //neutral
 }
@@ -10272,7 +10272,7 @@ void Client::SendPVPStats()
 	QueuePacket(outapp);
 	safe_delete(outapp);
 }
-void Client::SendPVPLeaderBoard() 
+void Client::SendPVPLeaderBoard()
 {
 	auto outapp = new EQApplicationPacket(OP_PVPLeaderBoardReply, sizeof(PVPLeaderBoard_Struct));
 	PVPLeaderBoard_Struct *pvplb = (PVPLeaderBoard_Struct *)outapp->pBuffer;
@@ -10282,39 +10282,48 @@ void Client::SendPVPLeaderBoard()
 	QueuePacket(outapp);
 	safe_delete(outapp);
 }
-int Client::CalculatePVPPoints(Client* killer, Client* victim) 
+int Client::CalculatePVPPoints(Client* killer, Client* victim)
 {
 	float points;
 	float pvp_points;
 	float level_difference;
-	float scoring_modifier;	
+	float scoring_modifier;
 	float infamy_difference;
 	int divider_modifier;
 	int currentkillerpoints;
 	int vitality = victim->m_pp.PVPVitality;
 
 	level_difference = victim->GetLevel() - killer->GetLevel();
-	
-	infamy_difference = victim->m_pp.PVPInfamy - killer->m_pp.PVPInfamy; 
-		
-	scoring_modifier = ( level_difference + infamy_difference + (vitality*=-1.0) ) * 5.0;
-		
+
+	infamy_difference = victim->m_pp.PVPInfamy - killer->m_pp.PVPInfamy;
+
+	//scoring_modifier = ( level_difference + infamy_difference + (vitality*=-1.0) ) * 5.0;
+
+	//if the level difference is positive, don't let infamy difference zero out score
+	if(level_difference>0 && infamy_difference<0 ){
+		scoring_modifier = level_difference;
+	}
+
+	scoring_modifier = ( level_difference + infamy_difference );
+
+	//if there is 1 kill in the last 24 hrs, divier_modifier = 1, if 2 kills, =2.
+	//if there are 0 kills in the last 24 hrs, =1.
 	divider_modifier = database.GetKillCount24Hours(killer, victim);
 
 	// naez: only get points per 24 hour yt
-	if (divider_modifier > 1) { // > 1 cuz if theres 0 the func returns 1
+	if (divider_modifier > 1) {
 		return 0;
 	}
-		
-	points = (100 + scoring_modifier);
+
+	points = (2 + scoring_modifier); //brynja: base score of 2
 
 	currentkillerpoints = killer->m_pp.PVPCurrentPoints;
-	
-        if (divider_modifier > 1) {	
+
+        if (divider_modifier > 1) {	 //brynja: is this whole thing redundant?
             for (int i=divider_modifier; i > 0; i--)
-            {		
+            {
                 points = points / 2;
-              		  
+
                 if (points < 1.0) {
                     pvp_points = (divider_modifier + scoring_modifier) * divider_modifier / 5;
 				} else {
@@ -10334,11 +10343,11 @@ int Client::CalculatePVPPoints(Client* killer, Client* victim)
 void Client::HandlePVPDeath(void)
 {
 	m_pp.PVPDeaths += 1;
-	m_pp.PVPVitality = 10;	
+	m_pp.PVPInfamy = 0;
 	m_pp.PVPCurrentDeathStreak += 1;
 
 	if (m_pp.PVPCurrentDeathStreak > m_pp.PVPWorstDeathStreak)
-		m_pp.PVPWorstDeathStreak = m_pp.PVPCurrentDeathStreak;		
+		m_pp.PVPWorstDeathStreak = m_pp.PVPCurrentDeathStreak;
 
 	Save();
 
@@ -10352,8 +10361,17 @@ void Client::HandlePVPKill(uint32 Points)
 	m_pp.PVPKills +=1;
 	m_pp.PVPCurrentKillStreak +=1;
 	m_pp.PVPCurrentDeathStreak = 0;
+	//todo: add a rule for infamy cap
+	//if(m_pp.PVPInfamy<RuleB(World, PVPInfamyCap))
+	//{
+	//m_pp.PVPInfamy += 1;
+	//}
+	if(m_pp.PVPInfamy<16)
+	{
+	m_pp.PVPInfamy += 1; //Brynja: for now, 1 killstreak = 1 infamy, capped at 16
+	}
 
-	if (m_pp.PVPCurrentKillStreak > m_pp.PVPBestKillStreak)	
+	if (m_pp.PVPCurrentKillStreak > m_pp.PVPBestKillStreak)
 		m_pp.PVPBestKillStreak = m_pp.PVPCurrentKillStreak;
 
 	Save();
@@ -10839,17 +10857,6 @@ void Client::ApplyWeaponsStance()
 		weaponstance.spellbonus_enabled = false;
 	}
 }
-
-uint16 Client::GetDoorToolEntityId() const
-{
-	return m_door_tool_entity_id;
-}
-
-void Client::SetDoorToolEntityId(uint16 door_tool_entity_id)
-{
-	Client::m_door_tool_entity_id = door_tool_entity_id;
-}
-
 int GetMaxSpellGems()
 {
 	if (RuleI(Character, MaxSpellGems) > 0)
@@ -10861,4 +10868,13 @@ int GetMaxSpellGems()
 	}
 
 	return EQ::spells::SPELL_GEM_COUNT;
+}
+uint16 Client::GetDoorToolEntityId() const
+{
+	return m_door_tool_entity_id;
+}
+
+void Client::SetDoorToolEntityId(uint16 door_tool_entity_id)
+{
+	Client::m_door_tool_entity_id = door_tool_entity_id;
 }


### PR DESCRIPTION
Changes to attack.cpp
1) Remove group multipler bonus for pvp points awarded to grp members.
2) PVP points for a group kill are divided by number of group members and rounded down to nearest integer.

Changes to client.cpp
1)Remove vitality from all calculations. Unused at this time.
2) Edge case check where killer is lower level, but has more infamy than victim
3) on death, reset infamy to 0
4) on kill, give 1 infamy up to 16pt cap //todo: add rule for infamy cap