### PR TITLE
Spell File Changes, field163 to resist_per_level, field164 to resist_…

### DIFF
--- a/common/repositories/base/base_spells_new_repository.h
+++ b/common/repositories/base/base_spells_new_repository.h
@@ -34,8 +34,8 @@ public:
 		int         cast_time;
 		int         recovery_time;
 		int         recast_time;
-		int         buffdurationformula;
-		int         buffduration;
+		int         durationbase;
+		int         durationcap;
 		int         AEDuration;
 		int         mana;
 		int         effect_base_value1;
@@ -165,7 +165,7 @@ public:
 		int         new_icon;
 		int         spellanim;
 		int         uninterruptable;
-		int         ResistDiff;
+		int         resist_mod;
 		int         dot_stacking_exempt;
 		int         deleteable;
 		int         RecourseLink;
@@ -181,8 +181,8 @@ public:
 		int         field160;
 		int         reflectable;
 		int         bonushate;
-		int         field163;
-		int         field164;
+		int         resist_per_level;
+		int         resist_cap;
 		int         ldon_trap;
 		int         EndurCost;
 		int         EndurTimerIndex;
@@ -195,9 +195,9 @@ public:
 		int         EndurUpkeep;
 		int         numhitstype;
 		int         numhits;
-		int         pvpresistbase;
-		int         pvpresistcalc;
-		int         pvpresistcap;
+		int         pvp_resist_mod;
+		int         pvp_resist_per_level;
+		int         pvp_resist_cap;
 		int         spell_category;
 		int         pvp_duration;
 		int         pvp_duration_cap;
@@ -281,8 +281,8 @@ public:
 			"cast_time",
 			"recovery_time",
 			"recast_time",
-			"buffdurationformula",
-			"buffduration",
+			"durationbase",
+			"durationcap",
 			"AEDuration",
 			"mana",
 			"effect_base_value1",
@@ -412,7 +412,7 @@ public:
 			"new_icon",
 			"spellanim",
 			"uninterruptable",
-			"ResistDiff",
+			"resist_mod",
 			"dot_stacking_exempt",
 			"deleteable",
 			"RecourseLink",
@@ -428,8 +428,8 @@ public:
 			"field160",
 			"reflectable",
 			"bonushate",
-			"field163",
-			"field164",
+			"resist_per_level",
+			"resist_cap",
 			"ldon_trap",
 			"EndurCost",
 			"EndurTimerIndex",
@@ -442,9 +442,9 @@ public:
 			"EndurUpkeep",
 			"numhitstype",
 			"numhits",
-			"pvpresistbase",
-			"pvpresistcalc",
-			"pvpresistcap",
+			"pvp_resist_mod",
+			"pvp_resist_per_level",
+			"pvp_resist_cap",
 			"spell_category",
 			"pvp_duration",
 			"pvp_duration_cap",
@@ -553,8 +553,8 @@ public:
 		entry.cast_time            = 0;
 		entry.recovery_time        = 0;
 		entry.recast_time          = 0;
-		entry.buffdurationformula  = 7;
-		entry.buffduration         = 65;
+		entry.durationbase         = 7;
+		entry.durationcap          = 65;
 		entry.AEDuration           = 0;
 		entry.mana                 = 0;
 		entry.effect_base_value1   = 100;
@@ -684,7 +684,7 @@ public:
 		entry.new_icon             = 161;
 		entry.spellanim            = 0;
 		entry.uninterruptable      = 0;
-		entry.ResistDiff           = -150;
+		entry.resist_mod           = -150;
 		entry.dot_stacking_exempt  = 0;
 		entry.deleteable           = 0;
 		entry.RecourseLink         = 0;
@@ -700,8 +700,8 @@ public:
 		entry.field160             = 0;
 		entry.reflectable          = 0;
 		entry.bonushate            = 0;
-		entry.field163             = 100;
-		entry.field164             = -150;
+		entry.resist_per_level     = 100;
+		entry.resist_cap           = -150;
 		entry.ldon_trap            = 0;
 		entry.EndurCost            = 0;
 		entry.EndurTimerIndex      = 0;
@@ -714,9 +714,9 @@ public:
 		entry.EndurUpkeep          = 0;
 		entry.numhitstype          = 0;
 		entry.numhits              = 0;
-		entry.pvpresistbase        = -150;
-		entry.pvpresistcalc        = 100;
-		entry.pvpresistcap         = -150;
+		entry.pvp_resist_mod       = -150;
+		entry.pvp_resist_per_level = 100;
+		entry.pvp_resist_cap       = -150;
 		entry.spell_category       = -99;
 		entry.pvp_duration         = 0;
 		entry.pvp_duration_cap     = 0;
@@ -825,8 +825,8 @@ public:
 			entry.cast_time            = atoi(row[13]);
 			entry.recovery_time        = atoi(row[14]);
 			entry.recast_time          = atoi(row[15]);
-			entry.buffdurationformula  = atoi(row[16]);
-			entry.buffduration         = atoi(row[17]);
+			entry.durationbase         = atoi(row[16]);
+			entry.durationcap          = atoi(row[17]);
 			entry.AEDuration           = atoi(row[18]);
 			entry.mana                 = atoi(row[19]);
 			entry.effect_base_value1   = atoi(row[20]);
@@ -956,7 +956,7 @@ public:
 			entry.new_icon             = atoi(row[144]);
 			entry.spellanim            = atoi(row[145]);
 			entry.uninterruptable      = atoi(row[146]);
-			entry.ResistDiff           = atoi(row[147]);
+			entry.resist_mod           = atoi(row[147]);
 			entry.dot_stacking_exempt  = atoi(row[148]);
 			entry.deleteable           = atoi(row[149]);
 			entry.RecourseLink         = atoi(row[150]);
@@ -972,8 +972,8 @@ public:
 			entry.field160             = atoi(row[160]);
 			entry.reflectable          = atoi(row[161]);
 			entry.bonushate            = atoi(row[162]);
-			entry.field163             = atoi(row[163]);
-			entry.field164             = atoi(row[164]);
+			entry.resist_per_level     = atoi(row[163]);
+			entry.resist_cap           = atoi(row[164]);
 			entry.ldon_trap            = atoi(row[165]);
 			entry.EndurCost            = atoi(row[166]);
 			entry.EndurTimerIndex      = atoi(row[167]);
@@ -986,9 +986,9 @@ public:
 			entry.EndurUpkeep          = atoi(row[174]);
 			entry.numhitstype          = atoi(row[175]);
 			entry.numhits              = atoi(row[176]);
-			entry.pvpresistbase        = atoi(row[177]);
-			entry.pvpresistcalc        = atoi(row[178]);
-			entry.pvpresistcap         = atoi(row[179]);
+			entry.pvp_resist_mod       = atoi(row[177]);
+			entry.pvp_resist_per_level = atoi(row[178]);
+			entry.pvp_resist_cap       = atoi(row[179]);
 			entry.spell_category       = atoi(row[180]);
 			entry.pvp_duration         = atoi(row[181]);
 			entry.pvp_duration_cap     = atoi(row[182]);
@@ -1095,8 +1095,8 @@ public:
 		update_values.push_back(columns[13] + " = " + std::to_string(spells_new_entry.cast_time));
 		update_values.push_back(columns[14] + " = " + std::to_string(spells_new_entry.recovery_time));
 		update_values.push_back(columns[15] + " = " + std::to_string(spells_new_entry.recast_time));
-		update_values.push_back(columns[16] + " = " + std::to_string(spells_new_entry.buffdurationformula));
-		update_values.push_back(columns[17] + " = " + std::to_string(spells_new_entry.buffduration));
+		update_values.push_back(columns[16] + " = " + std::to_string(spells_new_entry.durationbase));
+		update_values.push_back(columns[17] + " = " + std::to_string(spells_new_entry.durationcap));
 		update_values.push_back(columns[18] + " = " + std::to_string(spells_new_entry.AEDuration));
 		update_values.push_back(columns[19] + " = " + std::to_string(spells_new_entry.mana));
 		update_values.push_back(columns[20] + " = " + std::to_string(spells_new_entry.effect_base_value1));
@@ -1226,7 +1226,7 @@ public:
 		update_values.push_back(columns[144] + " = " + std::to_string(spells_new_entry.new_icon));
 		update_values.push_back(columns[145] + " = " + std::to_string(spells_new_entry.spellanim));
 		update_values.push_back(columns[146] + " = " + std::to_string(spells_new_entry.uninterruptable));
-		update_values.push_back(columns[147] + " = " + std::to_string(spells_new_entry.ResistDiff));
+		update_values.push_back(columns[147] + " = " + std::to_string(spells_new_entry.resist_mod));
 		update_values.push_back(columns[148] + " = " + std::to_string(spells_new_entry.dot_stacking_exempt));
 		update_values.push_back(columns[149] + " = " + std::to_string(spells_new_entry.deleteable));
 		update_values.push_back(columns[150] + " = " + std::to_string(spells_new_entry.RecourseLink));
@@ -1242,8 +1242,8 @@ public:
 		update_values.push_back(columns[160] + " = " + std::to_string(spells_new_entry.field160));
 		update_values.push_back(columns[161] + " = " + std::to_string(spells_new_entry.reflectable));
 		update_values.push_back(columns[162] + " = " + std::to_string(spells_new_entry.bonushate));
-		update_values.push_back(columns[163] + " = " + std::to_string(spells_new_entry.field163));
-		update_values.push_back(columns[164] + " = " + std::to_string(spells_new_entry.field164));
+		update_values.push_back(columns[163] + " = " + std::to_string(spells_new_entry.resist_per_level));
+		update_values.push_back(columns[164] + " = " + std::to_string(spells_new_entry.resist_cap));
 		update_values.push_back(columns[165] + " = " + std::to_string(spells_new_entry.ldon_trap));
 		update_values.push_back(columns[166] + " = " + std::to_string(spells_new_entry.EndurCost));
 		update_values.push_back(columns[167] + " = " + std::to_string(spells_new_entry.EndurTimerIndex));
@@ -1256,9 +1256,9 @@ public:
 		update_values.push_back(columns[174] + " = " + std::to_string(spells_new_entry.EndurUpkeep));
 		update_values.push_back(columns[175] + " = " + std::to_string(spells_new_entry.numhitstype));
 		update_values.push_back(columns[176] + " = " + std::to_string(spells_new_entry.numhits));
-		update_values.push_back(columns[177] + " = " + std::to_string(spells_new_entry.pvpresistbase));
-		update_values.push_back(columns[178] + " = " + std::to_string(spells_new_entry.pvpresistcalc));
-		update_values.push_back(columns[179] + " = " + std::to_string(spells_new_entry.pvpresistcap));
+		update_values.push_back(columns[177] + " = " + std::to_string(spells_new_entry.pvp_resist_mod));
+		update_values.push_back(columns[178] + " = " + std::to_string(spells_new_entry.pvp_resist_per_level));
+		update_values.push_back(columns[179] + " = " + std::to_string(spells_new_entry.pvp_resist_cap));
 		update_values.push_back(columns[180] + " = " + std::to_string(spells_new_entry.spell_category));
 		update_values.push_back(columns[181] + " = " + std::to_string(spells_new_entry.pvp_duration));
 		update_values.push_back(columns[182] + " = " + std::to_string(spells_new_entry.pvp_duration_cap));
@@ -1353,8 +1353,8 @@ public:
 		insert_values.push_back(std::to_string(spells_new_entry.cast_time));
 		insert_values.push_back(std::to_string(spells_new_entry.recovery_time));
 		insert_values.push_back(std::to_string(spells_new_entry.recast_time));
-		insert_values.push_back(std::to_string(spells_new_entry.buffdurationformula));
-		insert_values.push_back(std::to_string(spells_new_entry.buffduration));
+		insert_values.push_back(std::to_string(spells_new_entry.durationbase));
+		insert_values.push_back(std::to_string(spells_new_entry.durationcap));
 		insert_values.push_back(std::to_string(spells_new_entry.AEDuration));
 		insert_values.push_back(std::to_string(spells_new_entry.mana));
 		insert_values.push_back(std::to_string(spells_new_entry.effect_base_value1));
@@ -1484,7 +1484,7 @@ public:
 		insert_values.push_back(std::to_string(spells_new_entry.new_icon));
 		insert_values.push_back(std::to_string(spells_new_entry.spellanim));
 		insert_values.push_back(std::to_string(spells_new_entry.uninterruptable));
-		insert_values.push_back(std::to_string(spells_new_entry.ResistDiff));
+		insert_values.push_back(std::to_string(spells_new_entry.resist_mod));
 		insert_values.push_back(std::to_string(spells_new_entry.dot_stacking_exempt));
 		insert_values.push_back(std::to_string(spells_new_entry.deleteable));
 		insert_values.push_back(std::to_string(spells_new_entry.RecourseLink));
@@ -1500,8 +1500,8 @@ public:
 		insert_values.push_back(std::to_string(spells_new_entry.field160));
 		insert_values.push_back(std::to_string(spells_new_entry.reflectable));
 		insert_values.push_back(std::to_string(spells_new_entry.bonushate));
-		insert_values.push_back(std::to_string(spells_new_entry.field163));
-		insert_values.push_back(std::to_string(spells_new_entry.field164));
+		insert_values.push_back(std::to_string(spells_new_entry.resist_per_level));
+		insert_values.push_back(std::to_string(spells_new_entry.resist_cap));
 		insert_values.push_back(std::to_string(spells_new_entry.ldon_trap));
 		insert_values.push_back(std::to_string(spells_new_entry.EndurCost));
 		insert_values.push_back(std::to_string(spells_new_entry.EndurTimerIndex));
@@ -1514,9 +1514,9 @@ public:
 		insert_values.push_back(std::to_string(spells_new_entry.EndurUpkeep));
 		insert_values.push_back(std::to_string(spells_new_entry.numhitstype));
 		insert_values.push_back(std::to_string(spells_new_entry.numhits));
-		insert_values.push_back(std::to_string(spells_new_entry.pvpresistbase));
-		insert_values.push_back(std::to_string(spells_new_entry.pvpresistcalc));
-		insert_values.push_back(std::to_string(spells_new_entry.pvpresistcap));
+		insert_values.push_back(std::to_string(spells_new_entry.pvp_resist_mod));
+		insert_values.push_back(std::to_string(spells_new_entry.pvp_resist_per_level));
+		insert_values.push_back(std::to_string(spells_new_entry.pvp_resist_cap));
 		insert_values.push_back(std::to_string(spells_new_entry.spell_category));
 		insert_values.push_back(std::to_string(spells_new_entry.pvp_duration));
 		insert_values.push_back(std::to_string(spells_new_entry.pvp_duration_cap));
@@ -1619,8 +1619,8 @@ public:
 			insert_values.push_back(std::to_string(spells_new_entry.cast_time));
 			insert_values.push_back(std::to_string(spells_new_entry.recovery_time));
 			insert_values.push_back(std::to_string(spells_new_entry.recast_time));
-			insert_values.push_back(std::to_string(spells_new_entry.buffdurationformula));
-			insert_values.push_back(std::to_string(spells_new_entry.buffduration));
+			insert_values.push_back(std::to_string(spells_new_entry.durationbase));
+			insert_values.push_back(std::to_string(spells_new_entry.durationcap));
 			insert_values.push_back(std::to_string(spells_new_entry.AEDuration));
 			insert_values.push_back(std::to_string(spells_new_entry.mana));
 			insert_values.push_back(std::to_string(spells_new_entry.effect_base_value1));
@@ -1750,7 +1750,7 @@ public:
 			insert_values.push_back(std::to_string(spells_new_entry.new_icon));
 			insert_values.push_back(std::to_string(spells_new_entry.spellanim));
 			insert_values.push_back(std::to_string(spells_new_entry.uninterruptable));
-			insert_values.push_back(std::to_string(spells_new_entry.ResistDiff));
+			insert_values.push_back(std::to_string(spells_new_entry.resist_mod));
 			insert_values.push_back(std::to_string(spells_new_entry.dot_stacking_exempt));
 			insert_values.push_back(std::to_string(spells_new_entry.deleteable));
 			insert_values.push_back(std::to_string(spells_new_entry.RecourseLink));
@@ -1766,8 +1766,8 @@ public:
 			insert_values.push_back(std::to_string(spells_new_entry.field160));
 			insert_values.push_back(std::to_string(spells_new_entry.reflectable));
 			insert_values.push_back(std::to_string(spells_new_entry.bonushate));
-			insert_values.push_back(std::to_string(spells_new_entry.field163));
-			insert_values.push_back(std::to_string(spells_new_entry.field164));
+			insert_values.push_back(std::to_string(spells_new_entry.resist_per_level));
+			insert_values.push_back(std::to_string(spells_new_entry.resist_cap));
 			insert_values.push_back(std::to_string(spells_new_entry.ldon_trap));
 			insert_values.push_back(std::to_string(spells_new_entry.EndurCost));
 			insert_values.push_back(std::to_string(spells_new_entry.EndurTimerIndex));
@@ -1780,9 +1780,9 @@ public:
 			insert_values.push_back(std::to_string(spells_new_entry.EndurUpkeep));
 			insert_values.push_back(std::to_string(spells_new_entry.numhitstype));
 			insert_values.push_back(std::to_string(spells_new_entry.numhits));
-			insert_values.push_back(std::to_string(spells_new_entry.pvpresistbase));
-			insert_values.push_back(std::to_string(spells_new_entry.pvpresistcalc));
-			insert_values.push_back(std::to_string(spells_new_entry.pvpresistcap));
+			insert_values.push_back(std::to_string(spells_new_entry.pvp_resist_mod));
+			insert_values.push_back(std::to_string(spells_new_entry.pvp_resist_per_level));
+			insert_values.push_back(std::to_string(spells_new_entry.pvp_resist_cap));
 			insert_values.push_back(std::to_string(spells_new_entry.spell_category));
 			insert_values.push_back(std::to_string(spells_new_entry.pvp_duration));
 			insert_values.push_back(std::to_string(spells_new_entry.pvp_duration_cap));
@@ -1889,8 +1889,8 @@ public:
 			entry.cast_time            = atoi(row[13]);
 			entry.recovery_time        = atoi(row[14]);
 			entry.recast_time          = atoi(row[15]);
-			entry.buffdurationformula  = atoi(row[16]);
-			entry.buffduration         = atoi(row[17]);
+			entry.durationbase         = atoi(row[16]);
+			entry.durationcap          = atoi(row[17]);
 			entry.AEDuration           = atoi(row[18]);
 			entry.mana                 = atoi(row[19]);
 			entry.effect_base_value1   = atoi(row[20]);
@@ -2020,7 +2020,7 @@ public:
 			entry.new_icon             = atoi(row[144]);
 			entry.spellanim            = atoi(row[145]);
 			entry.uninterruptable      = atoi(row[146]);
-			entry.ResistDiff           = atoi(row[147]);
+			entry.resist_mod           = atoi(row[147]);
 			entry.dot_stacking_exempt  = atoi(row[148]);
 			entry.deleteable           = atoi(row[149]);
 			entry.RecourseLink         = atoi(row[150]);
@@ -2036,8 +2036,8 @@ public:
 			entry.field160             = atoi(row[160]);
 			entry.reflectable          = atoi(row[161]);
 			entry.bonushate            = atoi(row[162]);
-			entry.field163             = atoi(row[163]);
-			entry.field164             = atoi(row[164]);
+			entry.resist_per_level     = atoi(row[163]);
+			entry.resist_cap           = atoi(row[164]);
 			entry.ldon_trap            = atoi(row[165]);
 			entry.EndurCost            = atoi(row[166]);
 			entry.EndurTimerIndex      = atoi(row[167]);
@@ -2050,9 +2050,9 @@ public:
 			entry.EndurUpkeep          = atoi(row[174]);
 			entry.numhitstype          = atoi(row[175]);
 			entry.numhits              = atoi(row[176]);
-			entry.pvpresistbase        = atoi(row[177]);
-			entry.pvpresistcalc        = atoi(row[178]);
-			entry.pvpresistcap         = atoi(row[179]);
+			entry.pvp_resist_mod       = atoi(row[177]);
+			entry.pvp_resist_per_level = atoi(row[178]);
+			entry.pvp_resist_cap       = atoi(row[179]);
 			entry.spell_category       = atoi(row[180]);
 			entry.pvp_duration         = atoi(row[181]);
 			entry.pvp_duration_cap     = atoi(row[182]);
@@ -2150,8 +2150,8 @@ public:
 			entry.cast_time            = atoi(row[13]);
 			entry.recovery_time        = atoi(row[14]);
 			entry.recast_time          = atoi(row[15]);
-			entry.buffdurationformula  = atoi(row[16]);
-			entry.buffduration         = atoi(row[17]);
+			entry.durationbase         = atoi(row[16]);
+			entry.durationcap          = atoi(row[17]);
 			entry.AEDuration           = atoi(row[18]);
 			entry.mana                 = atoi(row[19]);
 			entry.effect_base_value1   = atoi(row[20]);
@@ -2281,7 +2281,7 @@ public:
 			entry.new_icon             = atoi(row[144]);
 			entry.spellanim            = atoi(row[145]);
 			entry.uninterruptable      = atoi(row[146]);
-			entry.ResistDiff           = atoi(row[147]);
+			entry.resist_mod           = atoi(row[147]);
 			entry.dot_stacking_exempt  = atoi(row[148]);
 			entry.deleteable           = atoi(row[149]);
 			entry.RecourseLink         = atoi(row[150]);
@@ -2297,8 +2297,8 @@ public:
 			entry.field160             = atoi(row[160]);
 			entry.reflectable          = atoi(row[161]);
 			entry.bonushate            = atoi(row[162]);
-			entry.field163             = atoi(row[163]);
-			entry.field164             = atoi(row[164]);
+			entry.resist_per_level     = atoi(row[163]);
+			entry.resist_cap           = atoi(row[164]);
 			entry.ldon_trap            = atoi(row[165]);
 			entry.EndurCost            = atoi(row[166]);
 			entry.EndurTimerIndex      = atoi(row[167]);
@@ -2311,9 +2311,9 @@ public:
 			entry.EndurUpkeep          = atoi(row[174]);
 			entry.numhitstype          = atoi(row[175]);
 			entry.numhits              = atoi(row[176]);
-			entry.pvpresistbase        = atoi(row[177]);
-			entry.pvpresistcalc        = atoi(row[178]);
-			entry.pvpresistcap         = atoi(row[179]);
+			entry.pvp_resist_mod       = atoi(row[177]);
+			entry.pvp_resist_per_level = atoi(row[178]);
+			entry.pvp_resist_cap       = atoi(row[179]);
 			entry.spell_category       = atoi(row[180]);
 			entry.pvp_duration         = atoi(row[181]);
 			entry.pvp_duration_cap     = atoi(row[182]);

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1775,8 +1775,8 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
 		sp[tempid].cast_time=atoi(row[13]);
 		sp[tempid].recovery_time=atoi(row[14]);
 		sp[tempid].recast_time=atoi(row[15]);
-		sp[tempid].buffdurationformula=atoi(row[16]);
-		sp[tempid].buffduration=atoi(row[17]);
+		sp[tempid].durationbase=atoi(row[16]);
+		sp[tempid].durationcap=atoi(row[17]);
 		sp[tempid].AEDuration=atoi(row[18]);
 		sp[tempid].mana=atoi(row[19]);
 
@@ -1836,7 +1836,7 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
 
 		sp[tempid].new_icon=atoi(row[144]);
 		sp[tempid].uninterruptable=atoi(row[146]) != 0;
-		sp[tempid].ResistDiff=atoi(row[147]);
+		sp[tempid].resist_mod=atoi(row[147]);
 		sp[tempid].dot_stacking_exempt = atoi(row[148]) != 0;
 		sp[tempid].RecourseLink = atoi(row[150]);
 		sp[tempid].no_partial_resist = atoi(row[151]) != 0;
@@ -1849,7 +1849,8 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
 		sp[tempid].npc_no_los = atoi(row[159]) != 0;
 		sp[tempid].reflectable = atoi(row[161]) != 0;
 		sp[tempid].bonushate=atoi(row[162]);
-
+		sp[tempid].resist_per_level=atoi(row[163]);
+		sp[tempid].resist_cap=atoi(row[164]);
 		sp[tempid].ldon_trap = atoi(row[165]) != 0;
 		sp[tempid].EndurCost=atoi(row[166]);
 		sp[tempid].EndurTimerIndex=atoi(row[167]);
@@ -1858,9 +1859,9 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
 		sp[tempid].EndurUpkeep=atoi(row[174]);
 		sp[tempid].numhitstype = atoi(row[175]);
 		sp[tempid].numhits = atoi(row[176]);
-		sp[tempid].pvpresistbase=atoi(row[177]);
-		sp[tempid].pvpresistcalc=atoi(row[178]);
-		sp[tempid].pvpresistcap=atoi(row[179]);
+		sp[tempid].pvp_resist_mod=atoi(row[177]);
+		sp[tempid].pvp_resist_per_level=atoi(row[178]);
+		sp[tempid].pvp_resist_cap=atoi(row[179]);
 		sp[tempid].spell_category=atoi(row[180]);
 		sp[tempid].pvp_duration = atoi(row[181]);
 		sp[tempid].pvp_duration_cap = atoi(row[182]);

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1246,8 +1246,8 @@ struct SPDat_Spell_Struct
 /* 013 */	uint32 cast_time; // Cast time -- CASTINGTIME
 /* 014 */	uint32 recovery_time; // Recovery time -- RECOVERYDELAY
 /* 015 */	uint32 recast_time; // Recast same spell time -- SPELLDELAY
-/* 016 */	uint32 buffdurationformula; // -- DURATIONBASE
-/* 017 */	uint32 buffduration; // -- DURATIONCAP
+/* 016 */	uint32 durationbase; // -- DURATIONBASE
+/* 017 */	uint32 durationcap; // -- DURATIONCAP
 /* 018 */	uint32 AEDuration;	// sentinel, rain of something -- IMPACTDURATION
 /* 019 */	uint16 mana; // Mana Used -- MANACOST
 /* 020 */	int base[EFFECT_COUNT];	//various purposes -- BASEAFFECT1 .. BASEAFFECT12
@@ -1289,7 +1289,7 @@ struct SPDat_Spell_Struct
 /* 144 */	int16 new_icon;	// Spell icon used by the client in uifiles/default/spells??.tga, both for spell gems & buff window. Looks to depreciate icon & memicon -- NEW_ICON
 /* 145 */	//int16 spellanim; // Doesn't look like it's the same as #doanim, so not sure what this is, particles I think -- SPELL_EFFECT_INDEX
 /* 146 */	bool uninterruptable;	// Looks like anything != 0 is uninterruptable. Values are mostly -1, 0, & 1 (Fetid Breath = 90?) -- NO_INTERRUPT
-/* 147 */	int16 ResistDiff; // -- RESIST_MOD
+/* 147 */	int16 resist_mod; // -- RESIST_MOD
 /* 148 */	bool dot_stacking_exempt; // -- NOT_STACKABLE_DOT
 /* 149 */	//int deletable; // -- DELETE_OK
 /* 150 */	uint16 RecourseLink; // -- REFLECT_SPELLINDEX
@@ -1305,8 +1305,8 @@ struct SPDat_Spell_Struct
 /* 160 */	//bool feedbackable; // -- FEEDBACKABLE
 /* 161 */	bool reflectable; // -- REFLECTABLE
 /* 162 */	int bonushate; // -- HATE_MOD
-/* 163 */	//int resist_per_level; // -- RESIST_PER_LEVEL
-/* 164 */	//int resist_cap; // for most spells this appears to mimic ResistDiff -- RESIST_CAP
+/* 163 */	int resist_per_level; // -- RESIST_PER_LEVEL
+/* 164 */	int resist_cap; // for most spells this appears to mimic resist_mod -- RESIST_CAP
 /* 165 */	bool ldon_trap; //Flag found on all LDON trap / chest related spells. -- AFFECT_INANIMATE
 /* 166 */	int EndurCost; // -- STAMINA_COST
 /* 167 */	int8 EndurTimerIndex; // bad name, used for all spells -- TIMER_INDEX
@@ -1316,12 +1316,12 @@ struct SPDat_Spell_Struct
 /* 174 */	int EndurUpkeep; // -- ENDUR_UPKEEP
 /* 175 */	int numhitstype; // defines which type of behavior will tick down the numhit counter. -- LIMITED_USE_TYPE
 /* 176 */	int numhits; // -- LIMITED_USE_COUNT
-/* 177 */	int pvpresistbase; // -- PVP_RESIST_MOD
-/* 178 */	int pvpresistcalc; // -- PVP_RESIST_PER_LEVEL
-/* 179 */	int pvpresistcap; // -- PVP_RESIST_CAP
+/* 177 */	int pvp_resist_mod; // -- PVP_RESIST_MOD
+/* 178 */	int pvp_resist_per_level; // -- PVP_RESIST_PER_LEVEL
+/* 179 */	int pvp_resist_cap; // -- PVP_RESIST_CAP
 /* 180 */	int spell_category; // -- GLOBAL_GROUP
-/* 181 */	int pvp_duration; // buffdurationformula for PvP -- PVP_DURATION
-/* 182 */	int pvp_duration_cap; // buffduration for PvP -- PVP_DURATION_CAP
+/* 181 */	int pvp_duration; // durationbase for PvP -- PVP_DURATION
+/* 182 */	int pvp_duration_cap; // durationcap for PvP -- PVP_DURATION_CAP
 /* 183 */	int pcnpc_only_flag; // valid values are 0, 1 = PCs (and mercs), and 2 = NPCs (and not mercs) -- PCNPC_ONLY_FLAG
 /* 184 */	bool cast_not_standing; // this is checked in the client's EQ_Spell::IsCastWhileInvisSpell, this also blocks SE_InterruptCasting from affecting this spell -- CAST_NOT_STANDING
 /* 185 */	bool can_mgb; // 0=no, -1 or 1 = yes -- CAN_MGB

--- a/common/version.h
+++ b/common/version.h
@@ -31,10 +31,10 @@
  * Every time a Database SQL is added to Github increment CURRENT_BINARY_DATABASE_VERSION
  * number and make sure you update the manifest
  *
- * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
+ * Manifest: https://raw.githubusercontent.com/cybernine186/Code/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9172
+#define CURRENT_BINARY_DATABASE_VERSION 9178
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9028

--- a/utils/deprecated/spell_explorer.cpp
+++ b/utils/deprecated/spell_explorer.cpp
@@ -58,8 +58,8 @@ int main(int argc, char** argv) {
 		sp.cast_time=atoi(sep.arg[13]);
 		sp.recovery_time=atoi(sep.arg[14]);
 		sp.recast_time=atoi(sep.arg[15]);
-		sp.buffdurationformula=atoi(sep.arg[16]);
-		sp.buffduration=atoi(sep.arg[17]);
+		sp.durationbase=atoi(sep.arg[16]);
+		sp.durationcap=atoi(sep.arg[17]);
 		sp.AEDuration=atoi(sep.arg[18]);
 		sp.mana=atoi(sep.arg[19]);
 		
@@ -113,7 +113,7 @@ int main(int argc, char** argv) {
 			sp.spacing124[y]=atoi(sep.arg[124+y]);
 		}
 		
-		sp.ResistDiff=atoi(sep.arg[147]);
+		sp.resist_mod=atoi(sep.arg[147]);
 		sp.dot_stacking_exempt=atoi(sep.arg[148]);
 		sp.deletable=atoi(sep.arg[149]);
 		
@@ -147,8 +147,8 @@ int main(int argc, char** argv) {
 	printf("  cast_time: %d\n", s->cast_time);
 	printf("  recovery_time: %d\n", s->recovery_time);
 	printf("  recast_time: %d\n", s->recast_time);
-	printf("  buffdurationformula: %d\n", s->buffdurationformula);
-	printf("  buffduration: %d\n", s->buffduration);
+	printf("  durationbase: %d\n", s->durationbase);
+	printf("  durationcap: %d\n", s->durationcap);
 	printf("  AEDuration: %d\n", s->AEDuration);
 	printf("  mana: %d\n", s->mana);
 	printf("  base[12]: %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d\n", s->base[0], s->base[1], s->base[2], s->base[3], s->base[4], s->base[5], s->base[6], s->base[7], s->base[8], s->base[9], s->base[10], s->base[11]);

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -432,6 +432,7 @@
 9175|2021_09_29_enable_disable_bard_melody.sql
 9176|2021_10_03_disable_item_focus_effect.sql
 9177|2021_10_08_autofire_tgb_rules.sql
+9178|2021_11_01_pvp_spells.sql
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2021_11_01_pvp_spells.sql
+++ b/utils/sql/git/required/2021_11_01_pvp_spells.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `spells_new` CHANGE `field163` `resist_per_level` INT(11) NOT NULL DEFAULT '100';
+ALTER TABLE `spells_new` CHANGE `field164` `resist_cap` INT(11) NOT NULL DEFAULT '-150';
+ALTER TABLE `spells_new` CHANGE `pvpresistbase` `pvp_resist_mod` INT(11) NOT NULL DEFAULT '-150';
+ALTER TABLE `spells_new` CHANGE `pvpresistcalc` `pvp_resist_per_level` INT(11) NOT NULL DEFAULT '100';
+ALTER TABLE `spells_new` CHANGE `pvpresistcap` `pvp_resist_cap` INT(11) NOT NULL DEFAULT '-150';
+ALTER TABLE `spells_new` CHANGE `buffdurationformula` `durationbase` INT(11) NOT NULL DEFAULT '7';
+ALTER TABLE `spells_new` CHANGE `buffduration` `durationcap` INT(11) NOT NULL DEFAULT '65';

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -764,7 +764,7 @@ void Client::InspectBuffs(Client* Inspector, int Rank)
 			continue;
 		ib->spell_id[packet_index] = buffs[i].spellid;
 		if (Rank > 1)
-			ib->tics_remaining[packet_index] = spells[buffs[i].spellid].buffdurationformula == DF_Permanent ? 0xFFFFFFFF : buffs[i].ticsremaining;
+			ib->tics_remaining[packet_index] = spells[buffs[i].spellid].durationbase == DF_Permanent ? 0xFFFFFFFF : buffs[i].ticsremaining;
 		packet_index++;
 	}
 
@@ -1256,7 +1256,7 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	else {
 		// Bards can cast instant cast AAs while they are casting another song
 		if (spells[rank->spell].cast_time == 0 && GetClass() == BARD && IsBardSong(casting_spell_id)) {
-			if (!SpellFinished(rank->spell, entity_list.GetMob(target_id), EQ::spells::CastingSlot::AltAbility, spells[rank->spell].mana, -1, spells[rank->spell].ResistDiff, false)) {
+			if (!SpellFinished(rank->spell, entity_list.GetMob(target_id), EQ::spells::CastingSlot::AltAbility, spells[rank->spell].mana, -1, spells[rank->spell].resist_mod, false)) {
 				return;
 			}
 			ExpendAlternateAdvancementCharge(ability->id);

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1254,7 +1254,7 @@ bool Mob::PassCharismaCheck(Mob* caster, uint16 spell_id) {
 
 	if(!caster) return false;
 
-	if(spells[spell_id].ResistDiff <= -600)
+	if(spells[spell_id].resist_mod <= -600)
 		return true;
 
 	float resist_check = 0;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1563,7 +1563,7 @@ bool Client::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, b
 		float chance = aabonuses.SkillAttackProc[SBIndex::SKILLPROC_CHANCE] / 1000.0f;
 		if (zone->random.Roll(chance))
 			SpellFinished(aabonuses.SkillAttackProc[SBIndex::SKILLPROC_SPELL_ID], other, EQ::spells::CastingSlot::Item, 0, -1,
-						  spells[aabonuses.SkillAttackProc[SBIndex::SKILLPROC_SPELL_ID]].ResistDiff);
+						  spells[aabonuses.SkillAttackProc[SBIndex::SKILLPROC_SPELL_ID]].resist_mod);
 	}
 	other->Damage(this, my_hit.damage_done, SPELL_UNKNOWN, my_hit.skill, true, -1, false, m_specialattacks);
 
@@ -2333,7 +2333,7 @@ void NPC::Damage(Mob* other, int32 damage, uint16 spell_id, EQ::skills::SkillTyp
 			if (IsLDoNTrapped())
 			{
 				MessageString(Chat::Red, LDON_ACCIDENT_SETOFF2);
-				SpellFinished(GetLDoNTrapSpellID(), other, EQ::spells::CastingSlot::Item, 0, -1, spells[GetLDoNTrapSpellID()].ResistDiff, false);
+				SpellFinished(GetLDoNTrapSpellID(), other, EQ::spells::CastingSlot::Item, 0, -1, spells[GetLDoNTrapSpellID()].resist_mod, false);
 				SetLDoNTrapSpellID(0);
 				SetLDoNTrapped(false);
 				SetLDoNTrapDetected(false);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4985,7 +4985,7 @@ int32 Bot::CalcBotAAFocus(focusType type, uint32 aa_ID, uint32 points, uint16 sp
 				}
 				break;
 			case SE_LimitInstant:
-				if(spell.buffduration)
+				if(spell.durationcap)
 					LimitFound = true;
 				break;
 			case SE_LimitMaxLevel:
@@ -5020,7 +5020,7 @@ int32 Bot::CalcBotAAFocus(focusType type, uint32 aa_ID, uint32 points, uint16 sp
 				}
 				break;
 			case SE_LimitMinDur:
-				if (base1 > CalcBuffDuration_formula(GetLevel(), spell.buffdurationformula, spell.buffduration))
+				if (base1 > CalcBuffDuration_formula(GetLevel(), spell.durationbase, spell.durationcap))
 					LimitFound = true;
 				break;
 			case SE_LimitEffect:
@@ -5443,7 +5443,7 @@ int32 Bot::CalcBotFocusEffect(focusType bottype, uint16 focus_id, uint16 spell_i
 				break;
 			}
 			case SE_LimitInstant: {
-				if(spell.buffduration)
+				if(spell.durationcap)
 					return 0;
 				break;
 			}
@@ -5484,7 +5484,7 @@ int32 Bot::CalcBotFocusEffect(focusType bottype, uint16 focus_id, uint16 spell_i
 				}
 				break;
 			case SE_LimitMinDur:
-				if (focus_spell.base[i] > CalcBuffDuration_formula(GetLevel(), spell.buffdurationformula, spell.buffduration))
+				if (focus_spell.base[i] > CalcBuffDuration_formula(GetLevel(), spell.durationbase, spell.durationcap))
 					return 0;
 				break;
 			case SE_LimitEffect:
@@ -6011,7 +6011,7 @@ void Bot::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 max
 	//	kb_chance += (kb_chance * (100 - aabonuses.SpecialAttackKBProc[0]) / 100);
 
 	//	if (zone->random.Int(0, 99) < kb_chance)
-	//		SpellFinished(904, who, 10, 0, -1, spells[904].ResistDiff);
+	//		SpellFinished(904, who, 10, 0, -1, spells[904].resist_mod);
 	//		//who->Stun(100); Kayen: This effect does not stun on live, it only moves the NPC.
 	//}
 
@@ -6757,7 +6757,7 @@ int32 Bot::GetActSpellHealing(uint16 spell_id, int32 value, Mob* target) {
 	value_BaseEffect = (value + (value*GetBotFocusEffect(focusFcBaseEffects, spell_id) / 100));
 	value = value_BaseEffect;
 	value += int(value_BaseEffect*GetBotFocusEffect(focusImprovedHeal, spell_id) / 100);
-	if(spells[spell_id].buffduration < 1) {
+	if(spells[spell_id].durationcap < 1) {
 		chance += (itembonuses.CriticalHealChance + spellbonuses.CriticalHealChance + aabonuses.CriticalHealChance);
 		chance += target->GetFocusIncoming(focusFcHealPctCritIncoming, SE_FcHealPctCritIncoming, this, spell_id);
 		if (spellbonuses.CriticalHealDecay)

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -221,7 +221,7 @@ public:
 					if (spells[spell_id].SpellAffectIndex != 12)
 						break;
 					entry_prototype = new STCharmEntry();
-					if (spells[spell_id].ResistDiff <= -1000)
+					if (spells[spell_id].resist_mod <= -1000)
 						entry_prototype->SafeCastToCharm()->dire = true;
 					break;
 				case SE_Teleport:
@@ -786,15 +786,15 @@ private:
 				continue;
 			case BCEnum::SpT_Charm:
 				spell_list->sort([](const STBaseEntry* l, const STBaseEntry* r) {
-					if (LT_SPELLS(l, r, ResistDiff))
+					if (LT_SPELLS(l, r, resist_mod))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && LT_STBASE(l, r, target_type))
+					if (EQ_SPELLS(l, r, resist_mod) && LT_STBASE(l, r, target_type))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && EQ_STBASE(l, r, target_type) && GT_SPELLS_EFFECT_ID(l, r, max, 1))
+					if (EQ_SPELLS(l, r, resist_mod) && EQ_STBASE(l, r, target_type) && GT_SPELLS_EFFECT_ID(l, r, max, 1))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 1) && LT_STBASE(l, r, spell_level))
+					if (EQ_SPELLS(l, r, resist_mod) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 1) && LT_STBASE(l, r, spell_level))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 1) && EQ_STBASE(l, r, spell_level) && LT_STBASE(l, r, caster_class))
+					if (EQ_SPELLS(l, r, resist_mod) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 1) && EQ_STBASE(l, r, spell_level) && LT_STBASE(l, r, caster_class))
 						return true;
 
 					return false;
@@ -895,15 +895,15 @@ private:
 				continue;
 			case BCEnum::SpT_Lull:
 				spell_list->sort([](const STBaseEntry* l, const STBaseEntry* r) {
-					if (LT_SPELLS(l, r, ResistDiff))
+					if (LT_SPELLS(l, r, resist_mod))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && LT_STBASE(l, r, target_type))
+					if (EQ_SPELLS(l, r, resist_mod) && LT_STBASE(l, r, target_type))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && EQ_STBASE(l, r, target_type) && GT_SPELLS_EFFECT_ID(l, r, max, 3))
+					if (EQ_SPELLS(l, r, resist_mod) && EQ_STBASE(l, r, target_type) && GT_SPELLS_EFFECT_ID(l, r, max, 3))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 3) && LT_STBASE(l, r, spell_level))
+					if (EQ_SPELLS(l, r, resist_mod) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 3) && LT_STBASE(l, r, spell_level))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 3) && EQ_STBASE(l, r, spell_level) && LT_STBASE(l, r, caster_class))
+					if (EQ_SPELLS(l, r, resist_mod) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 3) && EQ_STBASE(l, r, spell_level) && LT_STBASE(l, r, caster_class))
 						return true;
 
 					return false;
@@ -911,15 +911,15 @@ private:
 				continue;
 			case BCEnum::SpT_Mesmerize:
 				spell_list->sort([](const STBaseEntry* l, const STBaseEntry* r) {
-					if (GT_SPELLS(l, r, ResistDiff))
+					if (GT_SPELLS(l, r, resist_mod))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && LT_STBASE(l, r, target_type))
+					if (EQ_SPELLS(l, r, resist_mod) && LT_STBASE(l, r, target_type))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && EQ_STBASE(l, r, target_type) && GT_SPELLS_EFFECT_ID(l, r, max, 1))
+					if (EQ_SPELLS(l, r, resist_mod) && EQ_STBASE(l, r, target_type) && GT_SPELLS_EFFECT_ID(l, r, max, 1))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 1) && GT_STBASE(l, r, spell_level))
+					if (EQ_SPELLS(l, r, resist_mod) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 1) && GT_STBASE(l, r, spell_level))
 						return true;
-					if (EQ_SPELLS(l, r, ResistDiff) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 1) && EQ_STBASE(l, r, spell_level) && LT_STBASE(l, r, caster_class))
+					if (EQ_SPELLS(l, r, resist_mod) && EQ_STBASE(l, r, target_type) && EQ_SPELLS_EFFECT_ID(l, r, max, 1) && EQ_STBASE(l, r, spell_level) && LT_STBASE(l, r, caster_class))
 						return true;
 
 					return false;
@@ -1167,7 +1167,7 @@ private:
 
 				spell_dump << StringFormat(" /mn:%05u/RD:%06i/zt:%02i/d#:%06i/td#:%05i/ed#:%05i/SAI:%03u",
 					spells[spell_id].mana,
-					spells[spell_id].ResistDiff,
+					spells[spell_id].resist_mod,
 					spells[spell_id].zonetype,
 					spells[spell_id].descnum,
 					spells[spell_id].typedescnum,

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -843,7 +843,7 @@ bool BotDatabase::SaveBuffs(Bot* bot_inst)
 			bot_inst->GetBotID(),
 			bot_buffs[buff_index].spellid,
 			bot_buffs[buff_index].casterlevel,
-			spells[bot_buffs[buff_index].spellid].buffdurationformula,
+			spells[bot_buffs[buff_index].spellid].durationbase,
 			bot_buffs[buff_index].ticsremaining,
 			((CalculatePoisonCounters(bot_buffs[buff_index].spellid) > 0) ? (bot_buffs[buff_index].counters) : (0)),
 			((CalculateDiseaseCounters(bot_buffs[buff_index].spellid) > 0) ? (bot_buffs[buff_index].counters) : (0)),

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -606,7 +606,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 
 					if(CheckSpellRecastTimers(this, itr->SpellIndex))
 					{
-						if(!(!tar->IsImmuneToSpell(selectedBotSpell.SpellId, this) && (spells[selectedBotSpell.SpellId].buffduration < 1 || tar->CanBuffStack(selectedBotSpell.SpellId, botLevel, true) >= 0)))
+						if(!(!tar->IsImmuneToSpell(selectedBotSpell.SpellId, this) && (spells[selectedBotSpell.SpellId].durationcap < 1 || tar->CanBuffStack(selectedBotSpell.SpellId, botLevel, true) >= 0)))
 							continue;
 
 						//short duration buffs or other buffs only to be cast during combat.
@@ -868,7 +868,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 					case BEASTLORD: {
 						botSpell = GetBestBotSpellForDiseaseBasedSlow(this);
 
-						if(botSpell.SpellId == 0 || ((tar->GetMR() - 50) < (tar->GetDR() + spells[botSpell.SpellId].ResistDiff)))
+						if(botSpell.SpellId == 0 || ((tar->GetMR() - 50) < (tar->GetDR() + spells[botSpell.SpellId].resist_mod)))
 							botSpell = GetBestBotSpellForMagicBasedSlow(this);
 						break;
 					}
@@ -1111,7 +1111,7 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 		//	// Bard buff songs have been moved to their own npc spell type..
 		//	// Buff stacking is now checked as opposed to manipulating the timer to avoid rapid casting
 
-		//	//AIspells[i].time_cancast = (spells[AIspells[i].spellid].recast_time > (spells[AIspells[i].spellid].buffduration * 6000)) ? Timer::GetCurrentTime() + spells[AIspells[i].spellid].recast_time : Timer::GetCurrentTime() + spells[AIspells[i].spellid].buffduration * 6000;
+		//	//AIspells[i].time_cancast = (spells[AIspells[i].spellid].recast_time > (spells[AIspells[i].spellid].durationcap * 6000)) ? Timer::GetCurrentTime() + spells[AIspells[i].spellid].recast_time : Timer::GetCurrentTime() + spells[AIspells[i].spellid].durationcap * 6000;
 		//	//spellend_timer.Start(spells[AIspells[i].spellid].cast_time);
 		//}
 		//else
@@ -2265,26 +2265,26 @@ BotSpell Bot::GetBestBotWizardNukeSpellByTargetResists(Bot* botCaster, Mob* targ
 			bool spellSelected = false;
 
 			if(CheckSpellRecastTimers(botCaster, botSpellListItr->SpellIndex)) {
-				if(selectLureNuke && (spells[botSpellListItr->SpellId].ResistDiff < lureResisValue)) {
+				if(selectLureNuke && (spells[botSpellListItr->SpellId].resist_mod < lureResisValue)) {
 					spellSelected = true;
 				}
 				else if(IsPureNukeSpell(botSpellListItr->SpellId)) {
 					if(((target->GetMR() < target->GetCR()) || (target->GetMR() < target->GetFR())) && (GetSpellResistType(botSpellListItr->SpellId) == RESIST_MAGIC)
-						&& (spells[botSpellListItr->SpellId].ResistDiff > lureResisValue))
+						&& (spells[botSpellListItr->SpellId].resist_mod > lureResisValue))
 					{
 						spellSelected = true;
 					}
 					else if(((target->GetCR() < target->GetMR()) || (target->GetCR() < target->GetFR())) && (GetSpellResistType(botSpellListItr->SpellId) == RESIST_COLD)
-						&& (spells[botSpellListItr->SpellId].ResistDiff > lureResisValue))
+						&& (spells[botSpellListItr->SpellId].resist_mod > lureResisValue))
 					{
 						spellSelected = true;
 					}
 					else if(((target->GetFR() < target->GetCR()) || (target->GetFR() < target->GetMR())) && (GetSpellResistType(botSpellListItr->SpellId) == RESIST_FIRE)
-						&& (spells[botSpellListItr->SpellId].ResistDiff > lureResisValue))
+						&& (spells[botSpellListItr->SpellId].resist_mod > lureResisValue))
 					{
 						spellSelected = true;
 					}
-					else if((GetSpellResistType(botSpellListItr->SpellId) == RESIST_MAGIC) && (spells[botSpellListItr->SpellId].ResistDiff > lureResisValue) && !IsStunSpell(botSpellListItr->SpellId)) {
+					else if((GetSpellResistType(botSpellListItr->SpellId) == RESIST_MAGIC) && (spells[botSpellListItr->SpellId].resist_mod > lureResisValue) && !IsStunSpell(botSpellListItr->SpellId)) {
 						firstWizardMagicNukeSpellFound.SpellId = botSpellListItr->SpellId;
 						firstWizardMagicNukeSpellFound.SpellIndex = botSpellListItr->SpellIndex;
 						firstWizardMagicNukeSpellFound.ManaCost = botSpellListItr->ManaCost;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4964,7 +4964,7 @@ void Client::HandleLDoNOpen(NPC *target)
 			if(target->GetLDoNTrapSpellID() != 0)
 			{
 				MessageString(Chat::Red, LDON_ACCIDENT_SETOFF2);
-				target->SpellFinished(target->GetLDoNTrapSpellID(), this, EQ::spells::CastingSlot::Item, 0, -1, spells[target->GetLDoNTrapSpellID()].ResistDiff);
+				target->SpellFinished(target->GetLDoNTrapSpellID(), this, EQ::spells::CastingSlot::Item, 0, -1, spells[target->GetLDoNTrapSpellID()].resist_mod);
 				target->SetLDoNTrapSpellID(0);
 				target->SetLDoNTrapped(false);
 				target->SetLDoNTrapDetected(false);
@@ -5086,7 +5086,7 @@ void Client::HandleLDoNDisarm(NPC *target, uint16 skill, uint8 type)
 				break;
 			case -1:
 				MessageString(Chat::Red, LDON_ACCIDENT_SETOFF2);
-				target->SpellFinished(target->GetLDoNTrapSpellID(), this, EQ::spells::CastingSlot::Item, 0, -1, spells[target->GetLDoNTrapSpellID()].ResistDiff);
+				target->SpellFinished(target->GetLDoNTrapSpellID(), this, EQ::spells::CastingSlot::Item, 0, -1, spells[target->GetLDoNTrapSpellID()].resist_mod);
 				target->SetLDoNTrapSpellID(0);
 				target->SetLDoNTrapped(false);
 				target->SetLDoNTrapDetected(false);
@@ -5105,7 +5105,7 @@ void Client::HandleLDoNPickLock(NPC *target, uint16 skill, uint8 type)
 			if(target->IsLDoNTrapped())
 			{
 				MessageString(Chat::Red, LDON_ACCIDENT_SETOFF2);
-				target->SpellFinished(target->GetLDoNTrapSpellID(), this, EQ::spells::CastingSlot::Item, 0, -1, spells[target->GetLDoNTrapSpellID()].ResistDiff);
+				target->SpellFinished(target->GetLDoNTrapSpellID(), this, EQ::spells::CastingSlot::Item, 0, -1, spells[target->GetLDoNTrapSpellID()].resist_mod);
 				target->SetLDoNTrapSpellID(0);
 				target->SetLDoNTrapped(false);
 				target->SetLDoNTrapDetected(false);
@@ -10312,7 +10312,7 @@ int Client::CalculatePVPPoints(Client* killer, Client* victim)
 
 	//Brynja:if there are 0 or 1 kill in the last 24 hrs, GetKillCount24Hours = 1,
 	//if 2 kills, =2.
-	if (database.GetKillCountDays(killer, victim, RuleI(World, PVPKillCountDays)) > RuleI(World, PVPKillCountDaysLimit))
+	if (database.GetKillCountDays(killer, victim, RuleI(World, PVPKillCountDays) > RuleI(World, PVPKillCountDaysLimit)))
 		points = 0;
 
 	if (points < 0)
@@ -10345,8 +10345,8 @@ void Client::HandlePVPKill(uint32 Points)
 	m_pp.PVPCurrentKillStreak +=1;
 	m_pp.PVPCurrentDeathStreak = 0;
 
-	if (m_pp.PVPInfamy < RuleI(World, PVPInfamyCap) && Points > 0)
-		m_pp.PVPInfamy += 1;
+	if (m_pp.PVPInfamy < RuleI(World, PVPInfamyCap))
+		m_pp.PVPInfamy += 1; //Brynja: for now, 1 killstreak = 1 infamy
 
 	if (m_pp.PVPCurrentKillStreak > m_pp.PVPBestKillStreak)
 		m_pp.PVPBestKillStreak = m_pp.PVPCurrentKillStreak;

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -2999,12 +2999,12 @@ void command_castspell(Client *c, const Seperator *sep)
 		else
 			if (c->GetTarget() == 0)
 				if(c->Admin() >= commandInstacast)
-					c->SpellFinished(spellid, 0, EQ::spells::CastingSlot::Item, 0, -1, spells[spellid].ResistDiff);
+					c->SpellFinished(spellid, 0, EQ::spells::CastingSlot::Item, 0, -1, spells[spellid].resist_mod);
 				else
 					c->CastSpell(spellid, 0, EQ::spells::CastingSlot::Item, 0);
 			else
 				if(c->Admin() >= commandInstacast)
-					c->SpellFinished(spellid, c->GetTarget(), EQ::spells::CastingSlot::Item, 0, -1, spells[spellid].ResistDiff);
+					c->SpellFinished(spellid, c->GetTarget(), EQ::spells::CastingSlot::Item, 0, -1, spells[spellid].resist_mod);
 				else
 					c->CastSpell(spellid, c->GetTarget()->GetID(), EQ::spells::CastingSlot::Item, 0);
 	}
@@ -5615,8 +5615,8 @@ void command_spellinfo(Client *c, const Seperator *sep)
 		c->Message(Chat::White, "  cast_time: %d",  s->cast_time);
 		c->Message(Chat::White, "  recovery_time: %d",  s->recovery_time);
 		c->Message(Chat::White, "  recast_time: %d",  s->recast_time);
-		c->Message(Chat::White, "  buffdurationformula: %d",  s->buffdurationformula);
-		c->Message(Chat::White, "  buffduration: %d",  s->buffduration);
+		c->Message(Chat::White, "  durationbase: %d",  s->durationbase);
+		c->Message(Chat::White, "  durationcap: %d",  s->durationcap);
 		c->Message(Chat::White, "  AEDuration: %d",  s->AEDuration);
 		c->Message(Chat::White, "  mana: %d",  s->mana);
 		c->Message(Chat::White, "  base[12]: %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d",  s->base[0], s->base[1], s->base[2], s->base[3], s->base[4], s->base[5], s->base[6], s->base[7], s->base[8], s->base[9], s->base[10], s->base[11]);

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -286,7 +286,7 @@ int32 Mob::GetActSpellHealing(uint16 spell_id, int32 value, Mob* target) {
 	value += int(value_BaseEffect*GetFocusEffect(focusFcAmplifyMod, spell_id) / 100);
 
 	// Instant Heals
-	if(spells[spell_id].buffduration < 1) {
+	if(spells[spell_id].durationcap < 1) {
 
 		chance += itembonuses.CriticalHealChance + spellbonuses.CriticalHealChance + aabonuses.CriticalHealChance;
 
@@ -683,7 +683,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 	}
 
 	// the client does this check before calling CastSpell, should prevent discs being eaten
-	if (spell.buffdurationformula != 0 && spell.targettype == ST_Self && HasDiscBuff())
+	if (spell.durationbase != 0 && spell.targettype == ST_Self && HasDiscBuff())
 		return false;
 
 	//Check the disc timer

--- a/zone/lua_spell.cpp
+++ b/zone/lua_spell.cpp
@@ -96,12 +96,12 @@ uint32 Lua_Spell::GetRecastTime() {
 
 uint32 Lua_Spell::GetBuffdurationFormula() {
 	Lua_Safe_Call_Int();
-	return self->buffdurationformula;
+	return self->durationbase;
 }
 
 uint32 Lua_Spell::GetBuffDuration() {
 	Lua_Safe_Call_Int();
-	return self->buffduration;
+	return self->durationcap;
 }
 
 uint32 Lua_Spell::GetAEDuration() {
@@ -281,7 +281,7 @@ int Lua_Spell::GetUninterruptable() {
 
 int Lua_Spell::GetResistDiff() {
 	Lua_Safe_Call_Int();
-	return self->ResistDiff;
+	return self->resist_mod;
 }
 
 int Lua_Spell::GetRecourseLink() {
@@ -336,17 +336,17 @@ int Lua_Spell::GetNumHits() {
 
 int Lua_Spell::GetPVPResistBase() {
 	Lua_Safe_Call_Int();
-	return self->pvpresistbase;
+	return self->pvp_resist_mod;
 }
 
 int Lua_Spell::GetPVPResistCalc() {
 	Lua_Safe_Call_Int();
-	return self->pvpresistcalc;
+	return self->pvp_resist_per_level;
 }
 
 int Lua_Spell::GetPVPResistCap() {
 	Lua_Safe_Call_Int();
-	return self->pvpresistcap;
+	return self->pvp_resist_cap;
 }
 
 int Lua_Spell::GetSpellCategory() {
@@ -511,7 +511,7 @@ luabind::scope lua_register_spell() {
 		.def("CastTime", &Lua_Spell::GetCastTime)
 		.def("RecoveryTime", &Lua_Spell::GetRecoveryTime)
 		.def("RecastTime", &Lua_Spell::GetRecastTime)
-		.def("BuffdurationFormula", &Lua_Spell::GetBuffdurationFormula)
+		.def("durationbase", &Lua_Spell::GetBuffdurationFormula)
 		.def("BuffDuration", &Lua_Spell::GetBuffDuration)
 		.def("AEDuration", &Lua_Spell::GetAEDuration)
 		.def("Mana", &Lua_Spell::GetMana)
@@ -538,7 +538,7 @@ luabind::scope lua_register_spell() {
 		.def("DisallowSit", &Lua_Spell::GetDisallowSit)
 		.def("Deities", &Lua_Spell::GetDeities)
 		.def("Uninterruptable", &Lua_Spell::GetUninterruptable)
-		.def("ResistDiff", &Lua_Spell::GetResistDiff)
+		.def("resist_mod", &Lua_Spell::GetResistDiff)
 		.def("RecourseLink", &Lua_Spell::GetRecourseLink)
 		.def("ShortBuffBox", &Lua_Spell::GetShortBuffBox)
 		.def("DescNum", &Lua_Spell::GetDescNum)
@@ -549,9 +549,9 @@ luabind::scope lua_register_spell() {
 		.def("HateAdded", &Lua_Spell::GetHateAdded)
 		.def("EndurUpkeep", &Lua_Spell::GetEndurUpkeep)
 		.def("NumHits", &Lua_Spell::GetNumHits)
-		.def("PVPResistBase", &Lua_Spell::GetPVPResistBase)
-		.def("PVPResistCalc", &Lua_Spell::GetPVPResistCalc)
-		.def("PVPResistCap", &Lua_Spell::GetPVPResistCap)
+		.def("pvp_resist_mod", &Lua_Spell::GetPVPResistBase)
+		.def("pvp_resist_per_level", &Lua_Spell::GetPVPResistCalc)
+		.def("pvp_resist_cap", &Lua_Spell::GetPVPResistCap)
 		.def("SpellCategory", &Lua_Spell::GetSpellCategory)
 		.def("PVPDuration", &Lua_Spell::GetPVPDuration)
 		.def("PVPDurationCap", &Lua_Spell::GetPVPDurationCap)

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -3900,22 +3900,22 @@ MercSpell Merc::GetBestMercSpellForNukeByTargetResists(Merc* caster, Mob* target
 			// Assuming all the spells have been loaded into this list by level and in descending order
 
 			if(IsPureNukeSpell(mercSpellListItr->spellid) && !IsAENukeSpell(mercSpellListItr->spellid) && CheckSpellRecastTimers(caster, mercSpellListItr->spellid)) {
-				if(selectLureNuke && (spells[mercSpellListItr->spellid].ResistDiff < lureResisValue)) {
+				if(selectLureNuke && (spells[mercSpellListItr->spellid].resist_mod < lureResisValue)) {
 					spellSelected = true;
 				}
 				else {
 					if(((target->GetMR() < target->GetCR()) || (target->GetMR() < target->GetFR())) && (GetSpellResistType(mercSpellListItr->spellid) == RESIST_MAGIC)
-						&& (spells[mercSpellListItr->spellid].ResistDiff > lureResisValue))
+						&& (spells[mercSpellListItr->spellid].resist_mod > lureResisValue))
 					{
 						spellSelected = true;
 					}
 					else if(((target->GetCR() < target->GetMR()) || (target->GetCR() < target->GetFR())) && (GetSpellResistType(mercSpellListItr->spellid) == RESIST_COLD)
-						&& (spells[mercSpellListItr->spellid].ResistDiff > lureResisValue))
+						&& (spells[mercSpellListItr->spellid].resist_mod > lureResisValue))
 					{
 						spellSelected = true;
 					}
 					else if(((target->GetFR() < target->GetCR()) || (target->GetFR() < target->GetMR())) && (GetSpellResistType(mercSpellListItr->spellid) == RESIST_FIRE)
-						&& (spells[mercSpellListItr->spellid].ResistDiff > lureResisValue))
+						&& (spells[mercSpellListItr->spellid].resist_mod > lureResisValue))
 					{
 						spellSelected = true;
 					}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1678,7 +1678,7 @@ void Mob::ShowBuffs(Client* client) {
 	uint32 buff_count = GetMaxTotalSlots();
 	for (i=0; i < buff_count; i++) {
 		if (buffs[i].spellid != SPELL_UNKNOWN) {
-			if (spells[buffs[i].spellid].buffdurationformula == DF_Permanent)
+			if (spells[buffs[i].spellid].durationbase == DF_Permanent)
 				client->Message(Chat::White, "  %i: %s: Permanent", i, spells[buffs[i].spellid].name);
 			else
 				client->Message(Chat::White, "  %i: %s: %i tics left", i, spells[buffs[i].spellid].name, buffs[i].ticsremaining);
@@ -1712,7 +1712,7 @@ void Mob::ShowBuffList(Client* client) {
 	uint32 buff_count = GetMaxTotalSlots();
 	for (i = 0; i < buff_count; i++) {
 		if (buffs[i].spellid != SPELL_UNKNOWN) {
-			if (spells[buffs[i].spellid].buffdurationformula == DF_Permanent)
+			if (spells[buffs[i].spellid].durationbase == DF_Permanent)
 				client->Message(Chat::White, "  %i: %s: Permanent", i, spells[buffs[i].spellid].name);
 			else
 				client->Message(Chat::White, "  %i: %s: %i tics left", i, spells[buffs[i].spellid].name, buffs[i].ticsremaining);
@@ -3224,12 +3224,12 @@ void Mob::ExecWeaponProc(const EQ::ItemInstance *inst, uint16 spell_id, Mob *on,
 		twinproc = true;
 
 	if (IsBeneficialSpell(spell_id) && (!IsNPC() || (IsNPC() && CastToNPC()->GetInnateProcSpellID() != spell_id))) { // NPC innate procs don't take this path ever
-		SpellFinished(spell_id, this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff, true, level_override);
+		SpellFinished(spell_id, this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_mod, true, level_override);
 		if(twinproc)
 			SpellOnTarget(spell_id, this, false, false, 0, true, level_override);
 	}
 	else if(!(on->IsClient() && on->CastToClient()->dead)) { //dont proc on dead clients
-		SpellFinished(spell_id, on, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff, true, level_override);
+		SpellFinished(spell_id, on, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_mod, true, level_override);
 		if(twinproc)
 			SpellOnTarget(spell_id, on, false, false, 0, true, level_override);
 	}
@@ -3402,7 +3402,7 @@ int Mob::CountDispellableBuffs()
 		if(spells[buffs[x].spellid].goodEffect == 0)
 			continue;
 
-		if(buffs[x].spellid != SPELL_UNKNOWN &&	spells[buffs[x].spellid].buffdurationformula != DF_Permanent)
+		if(buffs[x].spellid != SPELL_UNKNOWN &&	spells[buffs[x].spellid].durationbase != DF_Permanent)
 			val++;
 	}
 	return val;
@@ -3596,13 +3596,13 @@ bool Mob::TrySpellTrigger(Mob *target, uint32 spell_id, int effect)
 
 	if (CastSpell) {
 		if (spells[spell_id].effectid[effect_slot] == SE_SpellTrigger && IsValidSpell(spells[spell_id].base2[effect_slot])) {
-			SpellFinished(spells[spell_id].base2[effect_slot], target, EQ::spells::CastingSlot::Item, 0, -1, spells[spells[spell_id].base2[effect_slot]].ResistDiff);
+			SpellFinished(spells[spell_id].base2[effect_slot], target, EQ::spells::CastingSlot::Item, 0, -1, spells[spells[spell_id].base2[effect_slot]].resist_mod);
 			return true;
 		}
 		else if (IsClient() & spells[spell_id].effectid[effect_slot] == SE_Chance_Best_in_Spell_Grp) {
 			uint32 best_spell_id = CastToClient()->GetHighestScribedSpellinSpellGroup(spells[spell_id].base2[effect_slot]);
 			if (IsValidSpell(best_spell_id)) {
-				SpellFinished(best_spell_id, target, EQ::spells::CastingSlot::Item, 0, -1, spells[best_spell_id].ResistDiff);
+				SpellFinished(best_spell_id, target, EQ::spells::CastingSlot::Item, 0, -1, spells[best_spell_id].resist_mod);
 			}
 			return true;//Do nothing if you don't have the any spell in spell group scribed.
 		}
@@ -3621,7 +3621,7 @@ void Mob::TryTriggerOnCastRequirement()
 				for (int i = 0; i < EFFECT_COUNT; i++) {
 					if ((spells[spell_id].effectid[i] == SE_TriggerOnReqTarget) || (spells[spell_id].effectid[i] == SE_TriggerOnReqCaster)) {
 						if (PassCastRestriction(spells[spell_id].base2[i])) {
-							SpellFinished(spells[spell_id].base[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff);
+							SpellFinished(spells[spell_id].base[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_mod);
 							if (!TryFadeEffect(e)) {
 								BuffFadeBySlot(e);
 							}
@@ -3648,7 +3648,7 @@ void Mob::TryTwincast(Mob *caster, Mob *target, uint32 spell_id)
 			if(zone->random.Roll(focus))
 			{
 				Message(Chat::Spells,"You twincast %s!", spells[spell_id].name);
-				SpellFinished(spell_id, target, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff);
+				SpellFinished(spell_id, target, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_mod);
 			}
 		}
 	}
@@ -3666,7 +3666,7 @@ void Mob::TryTwincast(Mob *caster, Mob *target, uint32 spell_id)
 				{
 					if(zone->random.Roll(focus))
 					{
-						SpellFinished(spell_id, target, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff);
+						SpellFinished(spell_id, target, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_mod);
 					}
 				}
 			}
@@ -3977,10 +3977,10 @@ bool Mob::TryFadeEffect(int slot)
 					if(IsValidSpell(spell_id))
 					{
 						if (IsBeneficialSpell(spell_id)) {
-							SpellFinished(spell_id, this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff);
+							SpellFinished(spell_id, this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_mod);
 						}
 						else if(!(IsClient() && CastToClient()->dead)) {
-							SpellFinished(spell_id, this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff);
+							SpellFinished(spell_id, this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_mod);
 						}
 						return true;
 					}
@@ -4014,7 +4014,7 @@ void Mob::TrySympatheticProc(Mob *target, uint32 spell_id)
 			SpellFinished(focus_trigger, target);
 
 		else
-			SpellFinished(focus_trigger, this, EQ::spells::CastingSlot::Item, 0, -1, spells[focus_trigger].ResistDiff);
+			SpellFinished(focus_trigger, this, EQ::spells::CastingSlot::Item, 0, -1, spells[focus_trigger].resist_mod);
 	}
 	// For detrimental spells, if the triggered spell is beneficial, then it will land on the caster
 	// if the triggered spell is also detrimental, then it will land on the target
@@ -4024,7 +4024,7 @@ void Mob::TrySympatheticProc(Mob *target, uint32 spell_id)
 			SpellFinished(focus_trigger, this);
 
 		else
-			SpellFinished(focus_trigger, target, EQ::spells::CastingSlot::Item, 0, -1, spells[focus_trigger].ResistDiff);
+			SpellFinished(focus_trigger, target, EQ::spells::CastingSlot::Item, 0, -1, spells[focus_trigger].resist_mod);
 	}
 
 	CheckNumHitsRemaining(NumHit::MatchingSpells, -1, focus_spell);
@@ -4339,7 +4339,7 @@ void Mob::TrySpellOnKill(uint8 level, uint16 spell_id)
 					if (IsValidSpell(spells[spell_id].base2[i]) && spells[spell_id].max[i] <= level)
 					{
 						if(zone->random.Roll(spells[spell_id].base[i]))
-							SpellFinished(spells[spell_id].base2[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spells[spell_id].base2[i]].ResistDiff);
+							SpellFinished(spells[spell_id].base2[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spells[spell_id].base2[i]].resist_mod);
 					}
 				}
 			}
@@ -4354,17 +4354,17 @@ void Mob::TrySpellOnKill(uint8 level, uint16 spell_id)
 
 		if(aabonuses.SpellOnKill[i] && IsValidSpell(aabonuses.SpellOnKill[i]) && (level >= aabonuses.SpellOnKill[i + 2])) {
 			if(zone->random.Roll(static_cast<int>(aabonuses.SpellOnKill[i + 1])))
-				SpellFinished(aabonuses.SpellOnKill[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[aabonuses.SpellOnKill[i]].ResistDiff);
+				SpellFinished(aabonuses.SpellOnKill[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[aabonuses.SpellOnKill[i]].resist_mod);
 		}
 
 		if(itembonuses.SpellOnKill[i] && IsValidSpell(itembonuses.SpellOnKill[i]) && (level >= itembonuses.SpellOnKill[i + 2])){
 			if(zone->random.Roll(static_cast<int>(itembonuses.SpellOnKill[i + 1])))
-				SpellFinished(itembonuses.SpellOnKill[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[aabonuses.SpellOnKill[i]].ResistDiff);
+				SpellFinished(itembonuses.SpellOnKill[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[aabonuses.SpellOnKill[i]].resist_mod);
 		}
 
 		if(spellbonuses.SpellOnKill[i] && IsValidSpell(spellbonuses.SpellOnKill[i]) && (level >= spellbonuses.SpellOnKill[i + 2])) {
 			if(zone->random.Roll(static_cast<int>(spellbonuses.SpellOnKill[i + 1])))
-				SpellFinished(spellbonuses.SpellOnKill[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[aabonuses.SpellOnKill[i]].ResistDiff);
+				SpellFinished(spellbonuses.SpellOnKill[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[aabonuses.SpellOnKill[i]].resist_mod);
 		}
 
 	}
@@ -4381,19 +4381,19 @@ bool Mob::TrySpellOnDeath()
 	for(int i = 0; i < MAX_SPELL_TRIGGER*2; i+=2) {
 		if(IsClient() && aabonuses.SpellOnDeath[i] && IsValidSpell(aabonuses.SpellOnDeath[i])) {
 			if(zone->random.Roll(static_cast<int>(aabonuses.SpellOnDeath[i + 1]))) {
-				SpellFinished(aabonuses.SpellOnDeath[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[aabonuses.SpellOnDeath[i]].ResistDiff);
+				SpellFinished(aabonuses.SpellOnDeath[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[aabonuses.SpellOnDeath[i]].resist_mod);
 			}
 		}
 
 		if(itembonuses.SpellOnDeath[i] && IsValidSpell(itembonuses.SpellOnDeath[i])) {
 			if(zone->random.Roll(static_cast<int>(itembonuses.SpellOnDeath[i + 1]))) {
-				SpellFinished(itembonuses.SpellOnDeath[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[itembonuses.SpellOnDeath[i]].ResistDiff);
+				SpellFinished(itembonuses.SpellOnDeath[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[itembonuses.SpellOnDeath[i]].resist_mod);
 			}
 		}
 
 		if(spellbonuses.SpellOnDeath[i] && IsValidSpell(spellbonuses.SpellOnDeath[i])) {
 			if(zone->random.Roll(static_cast<int>(spellbonuses.SpellOnDeath[i + 1]))) {
-				SpellFinished(spellbonuses.SpellOnDeath[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spellbonuses.SpellOnDeath[i]].ResistDiff);
+				SpellFinished(spellbonuses.SpellOnDeath[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spellbonuses.SpellOnDeath[i]].resist_mod);
 				}
 			}
 		}

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2929,7 +2929,7 @@ DBnpcspells_Struct *ZoneDatabase::GetNPCSpells(uint32 iDBSpellsID)
 			if (row[9])
 				entry.resist_adjust = atoi(row[9]);
 			else if (IsValidSpell(spell_id))
-				entry.resist_adjust = spells[spell_id].ResistDiff;
+				entry.resist_adjust = spells[spell_id].resist_mod;
 
 			spell_set.entries.push_back(entry);
 		}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1073,7 +1073,7 @@ bool NPC::DatabaseCastAccepted(int spell_id) {
 		}
 		case SE_CurrentHPOnce:
 		case SE_CurrentHP: {
-			if(this->GetHPRatio() < 100 && spells[spell_id].buffduration == 0)
+			if(this->GetHPRatio() < 100 && spells[spell_id].durationcap == 0)
 				return true;
 			else
 				return false;
@@ -1106,7 +1106,7 @@ bool NPC::DatabaseCastAccepted(int spell_id) {
 			break;
 		}
 		default:
-			if(spells[spell_id].goodEffect == 1 && !(spells[spell_id].buffduration == 0 && this->GetHPRatio() == 100) && !IsEngaged())
+			if(spells[spell_id].goodEffect == 1 && !(spells[spell_id].durationcap == 0 && this->GetHPRatio() == 100) && !IsEngaged())
 				return true;
 			return false;
 		}

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2796,7 +2796,7 @@ XS(XS_Mob_SpellFinished) {
 		if (items > 4) {
 			resist_diff = (int16) SvUV(ST(4));
 		} else {
-			resist_diff = spells[spell_id].ResistDiff;
+			resist_diff = spells[spell_id].resist_mod;
 		}
 
 		THIS->SpellFinished(spell_id, spell_target, EQ::spells::CastingSlot::Item, mana_cost, -1, resist_diff);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -372,14 +372,14 @@ void QuestManager::castspell(int spell_id, int target_id) {
 	if (owner) {
 		Mob *tgt = entity_list.GetMob(target_id);
 		if(tgt != nullptr)
-			owner->SpellFinished(spell_id, tgt, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff);
+			owner->SpellFinished(spell_id, tgt, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_mod);
 	}
 }
 
 void QuestManager::selfcast(int spell_id) {
 	QuestManagerCurrentQuestVars();
 	if (initiator)
-		initiator->SpellFinished(spell_id, initiator, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff);
+		initiator->SpellFinished(spell_id, initiator, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_mod);
 }
 
 void QuestManager::addloot(int item_id, int charges, bool equipitem, int aug1, int aug2, int aug3, int aug4, int aug5, int aug6) {

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -198,7 +198,7 @@ void Mob::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 bas
 		float chance = aabonuses.SkillAttackProc[SBIndex::SKILLPROC_CHANCE] / 1000.0f;
 		if (zone->random.Roll(chance))
 			SpellFinished(aabonuses.SkillAttackProc[SBIndex::SKILLPROC_SPELL_ID], who, EQ::spells::CastingSlot::Item, 0, -1,
-						  spells[aabonuses.SkillAttackProc[SBIndex::SKILLPROC_SPELL_ID]].ResistDiff);
+						  spells[aabonuses.SkillAttackProc[SBIndex::SKILLPROC_SPELL_ID]].resist_mod);
 	}
 
 	who->Damage(this, my_hit.damage_done, SPELL_UNKNOWN, skill, false);
@@ -1036,7 +1036,7 @@ void Mob::ProjectileAttack()
 					if (ProjectileAtk[i].skill == EQ::skills::SkillConjuration) {
 						if (IsValidSpell(ProjectileAtk[i].wpn_dmg))
 							SpellOnTarget(ProjectileAtk[i].wpn_dmg, target, false, true,
-								      spells[ProjectileAtk[i].wpn_dmg].ResistDiff,
+								      spells[ProjectileAtk[i].wpn_dmg].resist_mod,
 								      true);
 					} else {
 						CastToNPC()->DoRangedAttackDmg(
@@ -1056,7 +1056,7 @@ void Mob::ProjectileAttack()
 					else if (ProjectileAtk[i].skill == EQ::skills::SkillConjuration &&
 						 IsValidSpell(ProjectileAtk[i].wpn_dmg))
 						SpellOnTarget(ProjectileAtk[i].wpn_dmg, target, false, true,
-							      spells[ProjectileAtk[i].wpn_dmg].ResistDiff, true);
+							      spells[ProjectileAtk[i].wpn_dmg].resist_mod, true);
 				}
 			}
 
@@ -2228,7 +2228,7 @@ void Mob::DoMeleeSkillAttackDmg(Mob *other, uint16 weapon_damage, EQ::skills::Sk
 		float chance = aabonuses.SkillAttackProc[SBIndex::SKILLPROC_CHANCE] / 1000.0f;
 		if (zone->random.Roll(chance))
 			SpellFinished(aabonuses.SkillAttackProc[SBIndex::SKILLPROC_SPELL_ID], other, EQ::spells::CastingSlot::Item, 0, -1,
-						  spells[aabonuses.SkillAttackProc[SBIndex::SKILLPROC_SPELL_ID]].ResistDiff);
+						  spells[aabonuses.SkillAttackProc[SBIndex::SKILLPROC_SPELL_ID]].resist_mod);
 	}
 
 	other->Damage(this, damage, SPELL_UNKNOWN, skillinuse);

--- a/zone/trap.cpp
+++ b/zone/trap.cpp
@@ -136,7 +136,7 @@ void Trap::Trigger(Mob* trigger)
 				entity_list.MessageClose(trigger,false,100,13,"%s",message.c_str());
 			}
 			if(hiddenTrigger){
-				hiddenTrigger->SpellFinished(effectvalue, trigger, EQ::spells::CastingSlot::Item, 0, -1, spells[effectvalue].ResistDiff);
+				hiddenTrigger->SpellFinished(effectvalue, trigger, EQ::spells::CastingSlot::Item, 0, -1, spells[effectvalue].resist_mod);
 			}
 			break;
 		case trapTypeAlarm:

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3124,7 +3124,7 @@ void ZoneDatabase::SaveMercBuffs(Merc *merc) {
                             "caston_x, Persistent, caston_y, caston_z, ExtraDIChance) "
                             "VALUES (%u, %u, %u, %u, %u, %d, %u, %u, %u, %u, %u, %u, %u, %i, %u, %i, %i, %i);",
                             merc->GetMercID(), buffs[buffCount].spellid, buffs[buffCount].casterlevel,
-                            spells[buffs[buffCount].spellid].buffdurationformula, buffs[buffCount].ticsremaining,
+                            spells[buffs[buffCount].spellid].durationbase, buffs[buffCount].ticsremaining,
                             CalculatePoisonCounters(buffs[buffCount].spellid) > 0 ? buffs[buffCount].counters : 0,
                             CalculateDiseaseCounters(buffs[buffCount].spellid) > 0 ? buffs[buffCount].counters : 0,
                             CalculateCurseCounters(buffs[buffCount].spellid) > 0 ? buffs[buffCount].counters : 0,
@@ -4910,7 +4910,6 @@ uint32 ZoneDatabase::SaveSaylinkID(const char* saylink_text)
 
 	return results.LastInsertedID();
 }
-
 void ZoneDatabase::GetPVPKillsLast24Hours(Client* killer, PVPStats_Struct* pvps)
 {
 	int count = 1;
@@ -4941,7 +4940,6 @@ void ZoneDatabase::GetPVPKillsLast24Hours(Client* killer, PVPStats_Struct* pvps)
 		count++;
 	}
 }
-
 int ZoneDatabase::GetKillCountDays(Client* killer, Client* victim, int days)
 {
 	std::string query = StringFormat("SELECT COUNT(`id`) FROM `character_pvp_entries` WHERE `killer_id` = %i AND `victim_id` = %i AND `timestamp` <= TIMESTAMPADD(DAY, %i, NOW())", killer->CharacterID(), victim->CharacterID(), days);
@@ -4992,7 +4990,6 @@ void ZoneDatabase::GetPVPLeaderBoardDetails(PVPLeaderBoardDetailsReply_Struct* p
 		pvplbdr->Points = atoi(row[9]);
 	}
 }
-
 void ZoneDatabase::GetPVPLeaderBoard(Client* client, PVPLeaderBoard_Struct* pvplb, const char* sort_by)
 {
 	int count = 0;
@@ -5023,7 +5020,6 @@ void ZoneDatabase::GetPVPLeaderBoard(Client* client, PVPLeaderBoard_Struct* pvpl
 		count++;
 	}
 }
-
 bool ZoneDatabase::RegisterPVPKill(Client* killer, Client* victim, uint32 points)
 {
 	std::string query = StringFormat("INSERT INTO `character_pvp_entries` (`victim_id`, `victim_level`, `killer_id`, `killer_level`, `zone`, `points`, `timestamp`) VALUES (%i,%i,%i,%i,%i,%i,UNIX_TIMESTAMP())", victim->CharacterID(), victim->GetLevel(), killer->CharacterID(), killer->GetLevel(), zone->GetZoneID(), points);
@@ -5036,7 +5032,6 @@ bool ZoneDatabase::RegisterPVPKill(Client* killer, Client* victim, uint32 points
 
 	return true;
 }
-
 void ZoneDatabase::GetLastPVPKill(Client* killer, PVPStats_Struct* pvps)
 {
 	std::string query = StringFormat("SELECT `cd`.`name`, `cpe`.`victim_level`, `cd`.`race`, `cd`.`class`, `cpe`.`zone`, `cpe`.`timestamp`, `cpe`.`points` FROM `character_pvp_entries` `cpe` INNER JOIN `character_data` `cd` ON `cpe`.`victim_id` = `cd`.`id` WHERE `cpe`.`killer_id` = %i ORDER BY `cpe`.`timestamp` DESC LIMIT 1", killer->CharacterID());
@@ -5063,7 +5058,6 @@ void ZoneDatabase::GetLastPVPKill(Client* killer, PVPStats_Struct* pvps)
 		pvps->LastKill.Points = atoi(row[6]);
 	}
 }
-
 void ZoneDatabase::GetLastPVPDeath(Client* victim, PVPStats_Struct* pvps)
 {
 	std::string query = StringFormat("SELECT `cd`.`name`, `cpe`.`victim_level`, `cd`.`race`, `cd`.`class`, `cpe`.`zone`, `cpe`.`timestamp`, `cpe`.`points` FROM `character_pvp_entries` `cpe` INNER JOIN `character_data` `cd` ON `cpe`.`killer_id` = `cd`.`id` WHERE `cpe`.`victim_id` = %i ORDER BY `cpe`.`timestamp` DESC LIMIT 1", victim->CharacterID());


### PR DESCRIPTION
…cap, pvpresistbase to pvp_resist_mod, pvpresistcalc to pvp_resist_per_level, pvpresistcap to pvp_resist_cap, buffdurationformula to durationbase, and buffduration to durationcap. These are the correct field names.

TODO: Implement new fields resist_per_level, resist_cap along with pvp_resist_per_level and pvp_resist_cap. Appears these are used in spell resist. Refer to http://eqshadowknight.net/showthread.php?t=7232 for how spell resist check works.